### PR TITLE
Make vendor mismatch message optional

### DIFF
--- a/core/res/res/values/spark_config.xml
+++ b/core/res/res/values/spark_config.xml
@@ -229,4 +229,7 @@
 
     <!-- Whether device has fingerprint on power button -->
     <bool name="config_powerButtonFingerprint">false</bool>
+
+    <!-- Whether or not we should show vendor mismatch message -->
+    <bool name="config_show_vendor_mismatch_message">true</bool>
 </resources>

--- a/core/res/res/values/spark_strings.xml
+++ b/core/res/res/values/spark_strings.xml
@@ -71,4 +71,7 @@
     <!-- App Picker -->
     <string name="active_edge_app_select_title">Select app</string>
     <string name="active_edge_activity_select_title">Select activity</string>
+
+    <!-- Vendor mismatch fingerprint warning [CHAR LIMIT=NONE] -->
+    <string name="system_error_vendorprint">It appears your vendor image may be out of date. Please flash the latest vendor image for your device.</string>
 </resources>

--- a/core/res/res/values/spark_strings.xml
+++ b/core/res/res/values/spark_strings.xml
@@ -73,5 +73,5 @@
     <string name="active_edge_activity_select_title">Select activity</string>
 
     <!-- Vendor mismatch fingerprint warning [CHAR LIMIT=NONE] -->
-    <string name="system_error_vendorprint">It appears your vendor image may be out of date. Please flash the latest vendor image for your device.</string>
+    <string name="system_error_vendorprint">Your vendor image does not match the system. Please flash the <xliff:g id="string">%s</xliff:g> vendor image for your device</string>
 </resources>

--- a/core/res/res/values/spark_symbols.xml
+++ b/core/res/res/values/spark_symbols.xml
@@ -189,4 +189,7 @@
   <java-symbol type="layout" name="app_list_item" />
   <java-symbol type="string" name="active_edge_app_select_title" />
   <java-symbol type="string" name="active_edge_activity_select_title" />
+
+  <!-- Vendor mismatch fingerprint warning -->
+  <java-symbol type="string" name="system_error_vendorprint" />
 </resources>

--- a/core/res/res/values/spark_symbols.xml
+++ b/core/res/res/values/spark_symbols.xml
@@ -192,4 +192,7 @@
 
   <!-- Vendor mismatch fingerprint warning -->
   <java-symbol type="string" name="system_error_vendorprint" />
+
+  <!-- Whether or not we should show vendor mismatch message -->
+  <java-symbol type="bool" name="config_show_vendor_mismatch_message" />
 </resources>

--- a/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
+++ b/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
@@ -6533,7 +6533,9 @@ public class ActivityTaskManagerService extends IActivityTaskManager.Stub {
                 if (!Build.isBuildConsistent()) {
                     Slog.e(TAG, "Build fingerprint is not consistent, warning user");
                     mUiHandler.post(() -> {
-                        if (mShowDialogs) {
+                        boolean mShowVendorMismatch = Resources.getSystem().getBoolean(
+                                R.bool.config_show_vendor_mismatch_message);
+                        if (mShowDialogs && mShowVendorMismatch) {
                             String buildfingerprint = SystemProperties.get("ro.build.fingerprint");
                             String[] splitfingerprint = buildfingerprint.split("/");
                             String vendorid = splitfingerprint[3];

--- a/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
+++ b/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
@@ -6538,7 +6538,7 @@ public class ActivityTaskManagerService extends IActivityTaskManager.Stub {
                             d.getWindow().setType(WindowManager.LayoutParams.TYPE_SYSTEM_ERROR);
                             d.setCancelable(false);
                             d.setTitle(mUiContext.getText(R.string.android_system_label));
-                            d.setMessage(mUiContext.getText(R.string.system_error_manufacturer));
+                            d.setMessage(mUiContext.getText(R.string.system_error_vendorprint));
                             d.setButton(DialogInterface.BUTTON_POSITIVE,
                                     mUiContext.getText(R.string.ok),
                                     mUiHandler.obtainMessage(DISMISS_DIALOG_UI_MSG, d));

--- a/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
+++ b/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
@@ -6534,11 +6534,14 @@ public class ActivityTaskManagerService extends IActivityTaskManager.Stub {
                     Slog.e(TAG, "Build fingerprint is not consistent, warning user");
                     mUiHandler.post(() -> {
                         if (mShowDialogs) {
+                            String buildfingerprint = SystemProperties.get("ro.build.fingerprint");
+                            String[] splitfingerprint = buildfingerprint.split("/");
+                            String vendorid = splitfingerprint[3];
                             AlertDialog d = new BaseErrorDialog(mUiContext);
                             d.getWindow().setType(WindowManager.LayoutParams.TYPE_SYSTEM_ERROR);
                             d.setCancelable(false);
                             d.setTitle(mUiContext.getText(R.string.android_system_label));
-                            d.setMessage(mUiContext.getText(R.string.system_error_vendorprint));
+                            d.setMessage(mUiContext.getString(R.string.system_error_vendorprint, vendorid));
                             d.setButton(DialogInterface.BUTTON_POSITIVE,
                                     mUiContext.getText(R.string.ok),
                                     mUiHandler.obtainMessage(DISMISS_DIALOG_UI_MSG, d));


### PR DESCRIPTION
I was getting this warning on every boot with my OSS vendor though everything was working fine. I added these commits in Spark and got rid of the pointless warn.
![mismatch_warn](https://user-images.githubusercontent.com/4729640/122197277-4ef59400-ce98-11eb-88ef-7c66d29cf871.jpg)
