### PR TITLE
base: InputManager: handle housed stylus event

### DIFF
--- a/services/core/java/com/android/server/input/InputManagerService.java
+++ b/services/core/java/com/android/server/input/InputManagerService.java
@@ -307,6 +307,11 @@ public class InputManagerService extends IInputManager.Stub
     /** Switch code: Microphone. When set it is off. */
     public static final int SW_MUTE_DEVICE = 0x0e;
 
+    /** Switch code: Housed stylus. When set, stylus is inserted.
+    * {@hide}
+    */
+    public static final int SW_HOUSED_STYLUS = 0x0f;
+
     public static final int SW_LID_BIT = 1 << SW_LID;
     public static final int SW_TABLET_MODE_BIT = 1 << SW_TABLET_MODE;
     public static final int SW_KEYPAD_SLIDE_BIT = 1 << SW_KEYPAD_SLIDE;
@@ -318,6 +323,16 @@ public class InputManagerService extends IInputManager.Stub
             SW_HEADPHONE_INSERT_BIT | SW_MICROPHONE_INSERT_BIT | SW_JACK_PHYSICAL_INSERT_BIT | SW_LINEOUT_INSERT_BIT;
     public static final int SW_CAMERA_LENS_COVER_BIT = 1 << SW_CAMERA_LENS_COVER;
     public static final int SW_MUTE_DEVICE_BIT = 1 << SW_MUTE_DEVICE;
+ 
+    /**
+    * {@hide}
+    */
+    public static final int SW_HOUSED_STYLUS_BIT = 1 << SW_HOUSED_STYLUS;
+
+    /**
+    * {@hide}
+    */
+    public static final String SETTINGS_HOUSED_STYLUS_STATE = "pen_insert_state";
 
     /** Whether to use the dev/input/event or uevent subsystem for the audio jack. */
     final boolean mUseDevInputEventForAudioJack;
@@ -1936,6 +1951,12 @@ public class InputManagerService extends IInputManager.Stub
             final boolean micMute = ((switchValues & SW_MUTE_DEVICE_BIT) != 0);
             AudioManager audioManager = mContext.getSystemService(AudioManager.class);
             audioManager.setMicrophoneMuteFromSwitch(micMute);
+        }
+       
+        if ((switchMask & SW_HOUSED_STYLUS_BIT) != 0) {
+            int mPenState = (SW_HOUSED_STYLUS_BIT & switchValues) == 0 ? 0 : 1;
+            Settings.Global.putInt(mContext.getContentResolver(),
+                    SETTINGS_HOUSED_STYLUS_STATE, mPenState);
         }
     }
 


### PR DESCRIPTION
* Some phone may advertise for pulled off/inserted event
* Example : moto g stylus
  https://github.com/MotorolaMobilityLLC/motorola-kernel-modules/blob/android-10-release-qpg/drivers/misc/pen/bu520xx_pen.c