### PR TITLE
Squashed commit of the following:

### DIFF
--- a/apex/jobscheduler/framework/java/android/app/AlarmManager.java
+++ b/apex/jobscheduler/framework/java/android/app/AlarmManager.java
@@ -26,6 +26,7 @@ import android.annotation.SdkConstant.SdkConstantType;
 import android.annotation.SystemApi;
 import android.annotation.SystemService;
 import android.annotation.TestApi;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.ChangeId;
 import android.compat.annotation.EnabledSince;
 import android.compat.annotation.UnsupportedAppUsage;
@@ -912,6 +913,14 @@ public class AlarmManager {
             long intervalMillis, int flags, PendingIntent operation, final OnAlarmListener listener,
             String listenerTag, Executor targetExecutor, WorkSource workSource,
             AlarmClockInfo alarmClock) {
+        if (GmsCompat.isEnabled()) {
+            if (windowMillis == WINDOW_EXACT && !canScheduleExactAlarms()) {
+                windowMillis = WINDOW_HEURISTIC;
+            }
+            // non-null WorkSource requires privileged UPDATE_DEVICE_STATS permission
+            workSource = null;
+        }
+
         if (triggerAtMillis < 0) {
             /* NOTYET
             if (mAlwaysExact) {

--- a/core/api/system-current.txt
+++ b/core/api/system-current.txt
@@ -1272,6 +1272,15 @@ package android.app.compat {
 
 }
 
+package android.app.compat.gms {
+
+  public final class GmsCompat {
+    method public static boolean isEnabled();
+    method public static boolean isGmsApp(@NonNull String, int);
+  }
+
+}
+
 package android.app.contentsuggestions {
 
   public final class ClassificationsRequest implements android.os.Parcelable {

--- a/core/java/android/app/Activity.java
+++ b/core/java/android/app/Activity.java
@@ -39,6 +39,7 @@ import android.annotation.UiContext;
 import android.app.VoiceInteractor.Request;
 import android.app.admin.DevicePolicyManager;
 import android.app.assist.AssistContent;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.ComponentCallbacks2;
 import android.content.ComponentName;
@@ -147,6 +148,7 @@ import com.android.internal.annotations.VisibleForTesting;
 import com.android.internal.app.IVoiceInteractor;
 import com.android.internal.app.ToolbarActionBar;
 import com.android.internal.app.WindowDecorActionBar;
+import com.android.internal.gmscompat.PlayStoreHooks;
 import com.android.internal.policy.PhoneWindow;
 
 import dalvik.system.VMRuntime;
@@ -1971,6 +1973,10 @@ public class Activity extends ContextThemeWrapper
         notifyContentCaptureManagerIfNeeded(CONTENT_CAPTURE_RESUME);
 
         mCalled = true;
+
+        if (GmsCompat.isPlayStore()) {
+            PlayStoreHooks.activityResumed(this);
+        }
     }
 
     /**

--- a/core/java/android/app/ActivityManager.java
+++ b/core/java/android/app/ActivityManager.java
@@ -32,6 +32,7 @@ import android.annotation.SystemApi;
 import android.annotation.SystemService;
 import android.annotation.TestApi;
 import android.annotation.UserIdInt;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.ChangeId;
 import android.compat.annotation.EnabledSince;
 import android.compat.annotation.UnsupportedAppUsage;
@@ -83,6 +84,8 @@ import android.window.TaskSnapshot;
 
 import com.android.internal.app.LocalePicker;
 import com.android.internal.app.procstats.ProcessStats;
+import com.android.internal.gmscompat.GmsHooks;
+import com.android.internal.gmscompat.GmsUserHooks;
 import com.android.internal.os.RoSystemProperties;
 import com.android.internal.os.TransferPipe;
 import com.android.internal.util.FastPrintWriter;
@@ -3371,7 +3374,11 @@ public class ActivityManager {
      */
     public List<RunningAppProcessInfo> getRunningAppProcesses() {
         try {
-            return getService().getRunningAppProcesses();
+            List<RunningAppProcessInfo> res = getService().getRunningAppProcesses();
+            if (GmsCompat.isEnabled()) {
+                res = GmsHooks.addRecentlyBoundPids(mContext, res);
+            }
+            return res;
         } catch (RemoteException e) {
             throw e.rethrowFromSystemServer();
         }
@@ -4037,6 +4044,10 @@ public class ActivityManager {
             "android.permission.INTERACT_ACROSS_USERS_FULL"
     })
     public static int getCurrentUser() {
+        if (GmsCompat.isEnabled()) {
+            return GmsUserHooks.getCurrentUser();
+        }
+
         try {
             return getService().getCurrentUserId();
         } catch (RemoteException e) {
@@ -4281,6 +4292,10 @@ public class ActivityManager {
      */
     @UnsupportedAppUsage
     public boolean isUserRunning(int userId) {
+        if (GmsCompat.isEnabled()) {
+            return GmsUserHooks.isUserRunning(userId);
+        }
+
         try {
             return getService().isUserRunning(userId, 0);
         } catch (RemoteException e) {

--- a/core/java/android/app/ActivityThread.java
+++ b/core/java/android/app/ActivityThread.java
@@ -7954,4 +7954,15 @@ public final class ActivityThread extends ClientTransactionHandler
     private native void nPurgePendingResources();
     private native void nDumpGraphicsInfo(FileDescriptor fd);
     private native void nInitZygoteChildHeapProfiling();
+
+    public boolean hasAtLeastOneResumedActivity() {
+        synchronized (mResourcesManager) {
+            for (int i = 0; i < mActivities.size(); ++i) {
+                if (mActivities.valueAt(i).getLifecycleState() == ActivityLifecycleItem.ON_RESUME) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/core/java/android/app/AppOpsManager.java
+++ b/core/java/android/app/AppOpsManager.java
@@ -28,6 +28,7 @@ import android.annotation.RequiresPermission;
 import android.annotation.SystemApi;
 import android.annotation.SystemService;
 import android.annotation.TestApi;
+import android.app.compat.gms.GmsCompat;
 import android.app.usage.UsageStatsManager;
 import android.compat.Compatibility;
 import android.compat.annotation.ChangeId;
@@ -8263,6 +8264,10 @@ public class AppOpsManager {
      */
     public int noteOpNoThrow(int op, int uid, @Nullable String packageName,
             @Nullable String attributionTag, @Nullable String message) {
+        if (GmsCompat.isEnabled() && uid != Process.myUid()) {
+            return noteProxyOpNoThrow(op, packageName, uid, attributionTag, message);
+        }
+
         try {
             collectNoteOpCallsForValidation(op);
             int collectionMode = getNotedOpCollectionMode(uid, packageName, op);
@@ -8410,6 +8415,14 @@ public class AppOpsManager {
                 mContext.getAttributionSource(), new AttributionSource(proxiedUid,
                         proxiedPackageName, proxiedAttributionTag, mContext.getAttributionSource()
                         .getToken())), message,/*skipProxyOperation*/ false);
+    }
+
+    private int noteProxyOpNoThrow(int op, @Nullable String proxiedPackageName,
+            int proxiedUid, @Nullable String proxiedAttributionTag, @Nullable String message) {
+        return noteProxyOpNoThrow(op, new AttributionSource(
+                mContext.getAttributionSource(), new AttributionSource(proxiedUid,
+                proxiedPackageName, proxiedAttributionTag, mContext.getAttributionSource()
+                .getToken())), message,/*skipProxyOperation*/ false);
     }
 
     /**
@@ -8768,6 +8781,10 @@ public class AppOpsManager {
     public int startOpNoThrow(@NonNull IBinder token, int op, int uid, @NonNull String packageName,
             boolean startIfModeDefault, @Nullable String attributionTag, @Nullable String message,
             @AttributionFlags int attributionFlags, int attributionChainId) {
+        if (GmsCompat.isEnabled() && uid != Process.myUid()) {
+            return startProxyOpNoThrow(opToPublicName(op), uid, packageName, attributionTag, message);
+        }
+
         try {
             collectNoteOpCallsForValidation(op);
             int collectionMode = getNotedOpCollectionMode(uid, packageName, op);
@@ -8991,6 +9008,11 @@ public class AppOpsManager {
      */
     public void finishOp(IBinder token, int op, int uid, @NonNull String packageName,
             @Nullable String attributionTag) {
+        if (GmsCompat.isEnabled() && uid != Process.myUid()) {
+            finishProxyOp(opToPublicName(op), uid, packageName, attributionTag);
+            return;
+        }
+
         try {
             mService.finishOperation(token, op, uid, packageName, attributionTag);
         } catch (RemoteException e) {

--- a/core/java/android/app/BroadcastOptions.java
+++ b/core/java/android/app/BroadcastOptions.java
@@ -21,6 +21,7 @@ import android.annotation.Nullable;
 import android.annotation.RequiresPermission;
 import android.annotation.SystemApi;
 import android.annotation.TestApi;
+import android.app.compat.gms.GmsCompat;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.PowerExemptionManager;
@@ -167,6 +168,11 @@ public class BroadcastOptions {
             android.Manifest.permission.START_FOREGROUND_SERVICES_FROM_BACKGROUND})
     public void setTemporaryAppAllowlist(long duration, @TempAllowListType int type,
             @ReasonCode int reasonCode, @Nullable String reason) {
+        if (GmsCompat.isEnabled()) {
+            // otherwise, broadcasts (e.g. location updates via PendingIntent) from GMS fail
+            // due to lack of any of these privileged permission
+            return;
+        }
         mTemporaryAppAllowlistDuration = duration;
         mTemporaryAppAllowlistType = type;
         mTemporaryAppAllowlistReasonCode = reasonCode;
@@ -289,6 +295,10 @@ public class BroadcastOptions {
      */
     @RequiresPermission(android.Manifest.permission.START_ACTIVITIES_FROM_BACKGROUND)
     public void setBackgroundActivityStartsAllowed(boolean allowBackgroundActivityStarts) {
+        if (GmsCompat.isEnabled()) {
+            return;
+        }
+
         mAllowBackgroundActivityStarts = allowBackgroundActivityStarts;
     }
 

--- a/core/java/android/app/ContextImpl.java
+++ b/core/java/android/app/ContextImpl.java
@@ -25,6 +25,7 @@ import android.annotation.IntDef;
 import android.annotation.NonNull;
 import android.annotation.Nullable;
 import android.annotation.UiContext;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.AttributionSource;
 import android.content.AutofillOptions;
@@ -94,6 +95,8 @@ import android.window.WindowContext;
 import android.window.WindowTokenClient;
 
 import com.android.internal.annotations.GuardedBy;
+import com.android.internal.gmscompat.BinderRedirector;
+import com.android.internal.gmscompat.GmsHooks;
 import com.android.internal.util.Preconditions;
 
 import dalvik.system.BlockGuard;
@@ -1090,6 +1093,13 @@ class ContextImpl extends Context {
                             + " context requires the FLAG_ACTIVITY_NEW_TASK flag."
                             + " Is this really what you want?");
         }
+
+        if (GmsCompat.isEnabled()) {
+            if (GmsHooks.startActivity(intent, options)) {
+                return;
+            }
+        }
+
         mMainThread.getInstrumentation().execStartActivity(
                 getOuterContext(), mMainThread.getApplicationThread(), null,
                 (Activity) null, intent, -1, options);
@@ -1984,6 +1994,13 @@ class ContextImpl extends Context {
             throw new RuntimeException("Not supported in system context");
         }
         validateServiceIntent(service);
+
+        BinderRedirector.maybeInit(service);
+        if (GmsCompat.isEnabled()) {
+            // requires privileged START_ACTIVITIES_FROM_BACKGROUND permission
+            flags &= ~BIND_ALLOW_BACKGROUND_ACTIVITY_STARTS;
+        }
+
         try {
             IBinder token = getActivityToken();
             if (token == null && (flags&BIND_AUTO_CREATE) == 0 && mPackageInfo != null
@@ -2062,6 +2079,12 @@ class ContextImpl extends Context {
 
     @Override
     public Object getSystemService(String name) {
+        if (GmsCompat.isEnabled()) {
+            if (GmsHooks.isHiddenSystemService(name)) {
+                return null;
+            }
+        }
+
         if (vmIncorrectContextUseEnabled()) {
             // Check incorrect Context usage.
             if (WINDOW_SERVICE.equals(name) && !isUiContext()) {

--- a/core/java/android/app/DownloadManager.java
+++ b/core/java/android/app/DownloadManager.java
@@ -25,6 +25,7 @@ import android.annotation.SdkConstant.SdkConstantType;
 import android.annotation.SystemApi;
 import android.annotation.SystemService;
 import android.annotation.TestApi;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.ClipDescription;
 import android.content.ContentProviderClient;
@@ -714,6 +715,13 @@ public class DownloadManager {
          * @return this object
          */
         public Request setNotificationVisibility(int visibility) {
+            if (GmsCompat.isEnabled()) {
+                // requires the privileged DOWNLOAD_WITHOUT_NOTIFICATION permission
+                if (visibility == VISIBILITY_HIDDEN) {
+                    return this;
+                }
+            }
+
             mNotificationVisibility = visibility;
             return this;
         }

--- a/core/java/android/app/Instrumentation.java
+++ b/core/java/android/app/Instrumentation.java
@@ -19,6 +19,7 @@ package android.app;
 import android.annotation.IntDef;
 import android.annotation.NonNull;
 import android.annotation.Nullable;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
@@ -1187,6 +1188,7 @@ public class Instrumentation {
     public Application newApplication(ClassLoader cl, String className, Context context)
             throws InstantiationException, IllegalAccessException, 
             ClassNotFoundException {
+        GmsCompat.maybeEnable(context);
         Application app = getFactory(context.getPackageName())
                 .instantiateApplication(cl, className);
         app.attach(context);
@@ -1207,6 +1209,7 @@ public class Instrumentation {
     static public Application newApplication(Class<?> clazz, Context context)
             throws InstantiationException, IllegalAccessException, 
             ClassNotFoundException {
+        GmsCompat.maybeEnable(context);
         Application app = (Application)clazz.newInstance();
         app.attach(context);
         String packageName = app.getPackageName();

--- a/core/java/android/app/LoadedApk.java
+++ b/core/java/android/app/LoadedApk.java
@@ -59,6 +59,7 @@ import android.util.SparseArray;
 import android.view.DisplayAdjustments;
 
 import com.android.internal.annotations.GuardedBy;
+import com.android.internal.gmscompat.GmsHooks;
 import com.android.internal.util.ArrayUtils;
 
 import dalvik.system.BaseDexClassLoader;

--- a/core/java/android/app/admin/DevicePolicyManager.java
+++ b/core/java/android/app/admin/DevicePolicyManager.java
@@ -40,6 +40,7 @@ import android.app.Activity;
 import android.app.IServiceConnection;
 import android.app.KeyguardManager;
 import android.app.admin.SecurityLog.SecurityEvent;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.ComponentName;
 import android.content.Context;
@@ -5444,6 +5445,11 @@ public class DevicePolicyManager {
      */
     public @Nullable FactoryResetProtectionPolicy getFactoryResetProtectionPolicy(
             @Nullable ComponentName admin) {
+        if (GmsCompat.isEnabled()) {
+            // called during account removal to check whether it's allowed, requires privileged permissions
+            return null;
+        }
+
         throwIfParentInstance("getFactoryResetProtectionPolicy");
         if (mService != null) {
             try {
@@ -7879,6 +7885,10 @@ public class DevicePolicyManager {
             android.Manifest.permission.MANAGE_PROFILE_AND_DEVICE_OWNERS,
     })
     public ComponentName getDeviceOwnerComponentOnAnyUser() {
+        if (GmsCompat.isEnabled()) {
+            return null;
+        }
+
         return getDeviceOwnerComponentInner(/* callingUserOnly =*/ false);
     }
 
@@ -8013,6 +8023,10 @@ public class DevicePolicyManager {
     @SystemApi
     @RequiresPermission(android.Manifest.permission.MANAGE_USERS)
     public String getDeviceOwnerNameOnAnyUser() {
+        if (GmsCompat.isEnabled()) {
+            return null;
+        }
+
         throwIfParentInstance("getDeviceOwnerNameOnAnyUser");
         if (mService != null) {
             try {
@@ -8403,6 +8417,10 @@ public class DevicePolicyManager {
     @SystemApi
     @RequiresPermission(android.Manifest.permission.MANAGE_USERS)
     public @Nullable String getProfileOwnerNameAsUser(int userId) throws IllegalArgumentException {
+        if (GmsCompat.isEnabled()) {
+            return null;
+        }
+
         throwIfParentInstance("getProfileOwnerNameAsUser");
         if (mService != null) {
             try {
@@ -12100,6 +12118,10 @@ public class DevicePolicyManager {
     @SystemApi
     @RequiresPermission(android.Manifest.permission.MANAGE_USERS)
     public boolean isDeviceProvisioned() {
+        if (GmsCompat.isEnabled()) {
+            return true;
+        }
+
         try {
             return mService.isDeviceProvisioned();
         } catch (RemoteException re) {

--- a/core/java/android/app/backup/BackupManager.java
+++ b/core/java/android/app/backup/BackupManager.java
@@ -22,6 +22,7 @@ import android.annotation.Nullable;
 import android.annotation.RequiresPermission;
 import android.annotation.SystemApi;
 import android.app.compat.CompatChanges;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.ChangeId;
 import android.compat.annotation.EnabledAfter;
 import android.compat.annotation.UnsupportedAppUsage;
@@ -428,6 +429,10 @@ public class BackupManager {
     @SystemApi
     @RequiresPermission(android.Manifest.permission.BACKUP)
     public boolean isBackupEnabled() {
+        if (GmsCompat.isEnabled()) {
+            return false;
+        }
+
         checkServiceBinder();
         if (sService != null) {
             try {
@@ -460,6 +465,10 @@ public class BackupManager {
     @SystemApi
     @RequiresPermission(android.Manifest.permission.BACKUP)
     public boolean isBackupServiceActive(UserHandle user) {
+        if (GmsCompat.isEnabled()) {
+            return false;
+        }
+
         if (!CompatChanges.isChangeEnabled(
                 IS_BACKUP_SERVICE_ACTIVE_ENFORCE_PERMISSION_IN_SERVICE)) {
             mContext.enforceCallingOrSelfPermission(android.Manifest.permission.BACKUP,

--- a/core/java/android/app/compat/gms/GmsCompat.java
+++ b/core/java/android/app/compat/gms/GmsCompat.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.app.compat.gms;
+
+import android.annotation.NonNull;
+import android.annotation.SystemApi;
+import android.app.ActivityThread;
+import android.app.Application;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.IPackageManager;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.Signature;
+import android.content.pm.SigningInfo;
+import android.os.Binder;
+import android.os.Process;
+import android.os.RemoteException;
+import android.os.UserHandle;
+
+import com.android.internal.gmscompat.GmsHooks;
+import com.android.internal.gmscompat.GmsInfo;
+
+/**
+ * This class provides helpers for GMS ("Google Mobile Services") compatibility.
+ * It allows the following apps to work as regular, unprivileged user apps:
+ *     - GSF ("Google Services Framework")
+ *     - GMS Core ("Google Play services")
+ *     - Google Play Store
+ *     - Apps that depend on the above
+ *
+ * All GMS compatibility hooks should call methods on GmsCompat. Hooks that are more complicated
+ * than returning a simple constant value should also be implemented in GmsHooks to reduce
+ * maintenance overhead.
+ *
+ * @hide
+ */
+@SystemApi
+public final class GmsCompat {
+    private static final String TAG = "GmsCompat/Core";
+
+    private static boolean isGmsCompatEnabled;
+    private static boolean isGmsCore;
+    private static boolean isPlayStore;
+
+    private static boolean elegibleForClientCompat;
+
+    // Static only
+    private GmsCompat() { }
+
+    public static boolean isEnabled() {
+        return isGmsCompatEnabled;
+    }
+
+    /** @hide */
+    public static boolean isGmsCore() {
+        return isGmsCore;
+    }
+
+    /** @hide */
+    public static boolean isPlayStore() {
+        return isPlayStore;
+    }
+
+    private static Context appContext;
+
+    /** @hide */
+    public static Context appContext() {
+        return appContext;
+    }
+
+    /**
+     * Call from Instrumentation.newApplication() before Application class in instantiated to
+     * make sure init is completed in GMS processes before any of the app's code is executed.
+     *
+     * @hide
+     */
+    public static void maybeEnable(Context appCtx) {
+        if (!Process.isApplicationUid(Process.myUid())) {
+            // note that isApplicationUid() returns false for processes of services that have
+            // 'android:isolatedProcess="true"' directive in AndroidManifest, which is fine,
+            // because they have no need for GmsCompat
+            return;
+        }
+
+        appContext = appCtx;
+        ApplicationInfo appInfo = appCtx.getApplicationInfo();
+
+        if (isGmsApp(appInfo)) {
+            isGmsCompatEnabled = true;
+            String pkg = appInfo.packageName;
+            isGmsCore = GmsInfo.PACKAGE_GMS_CORE.equals(pkg);
+            isPlayStore = GmsInfo.PACKAGE_PLAY_STORE.equals(pkg);
+            GmsHooks.init(appCtx, pkg);
+        }
+        elegibleForClientCompat = !isGmsCore;
+    }
+
+    private static boolean validateCerts(Signature[] signatures) {
+        for (Signature signature : signatures) {
+            if (signature.toCharsString().equals(GmsInfo.SIGNING_CERT)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check whether the given app is unprivileged and part of the Google Play Services family.
+     * @hide
+     */
+    public static boolean isGmsApp(String packageName, Signature[] signatures,
+                                   Signature[] pastSignatures, boolean isPrivileged, String sharedUserId) {
+        // Privileged GMS doesn't need any compatibility changes
+        if (isPrivileged) {
+            return false;
+        }
+
+        if (GmsInfo.PACKAGE_GMS_CORE.equals(packageName) || GmsInfo.PACKAGE_GSF.equals(packageName)) {
+            // Check the shared user ID to avoid affecting microG with a spoofed signature. This is a
+            // reliable indicator because apps can't change their shared user ID after shipping with it.
+            if (!GmsInfo.SHARED_USER_ID.equals(sharedUserId)) {
+                return false;
+            }
+        } else if (!GmsInfo.PACKAGE_PLAY_STORE.equals(packageName)) {
+            return false;
+        }
+
+        // Validate signature to avoid affecting apps like microG and Gcam Services Provider.
+        // This isn't actually necessary from a security perspective because GMS doesn't get any
+        // special privileges, but it's a failsafe to avoid unintentional compatibility issues.
+        boolean validCert = validateCerts(signatures);
+
+        if (!validCert && pastSignatures != null) {
+            validCert = validateCerts(pastSignatures);
+        }
+        return validCert;
+    }
+
+    /** @hide */
+    public static boolean isGmsApp(ApplicationInfo app) {
+        return isGmsApp(app.packageName, UserHandle.getUserId(app.uid));
+    }
+
+    private static boolean isGmsPackageName(String pkg) {
+        return GmsInfo.PACKAGE_GMS_CORE.equals(pkg)
+            || GmsInfo.PACKAGE_PLAY_STORE.equals(pkg)
+            || GmsInfo.PACKAGE_GSF.equals(pkg);
+    }
+
+    public static boolean isGmsApp(@NonNull String packageName, int userId) {
+        return isGmsApp(packageName, userId, false);
+    }
+
+    /** @hide */
+    public static boolean isGmsApp(@NonNull String packageName, int userId, boolean matchDisabledApp) {
+        if (!isGmsPackageName(packageName)) {
+            return false;
+        }
+
+        IPackageManager pm = ActivityThread.getPackageManager();
+
+        PackageInfo pkg;
+        long token = Binder.clearCallingIdentity();
+        try {
+            pkg = pm.getPackageInfo(packageName, PackageManager.GET_SIGNING_CERTIFICATES, userId);
+            if (pkg == null) {
+                return false;
+            }
+        } catch (RemoteException e) {
+            throw e.rethrowFromSystemServer();
+        } finally {
+            Binder.restoreCallingIdentity(token);
+        }
+        return isGmsApp(pkg, matchDisabledApp);
+    }
+
+    /** @hide */
+    public static boolean isGmsApp(PackageInfo pkg, boolean matchDisabledApp) {
+        ApplicationInfo app = pkg.applicationInfo;
+        if (app == null) {
+            return false;
+        }
+        if (!app.enabled && !matchDisabledApp) {
+            return false;
+        }
+        SigningInfo si = pkg.signingInfo;
+        return isGmsApp(app.packageName,
+            si.getApkContentsSigners(), si.getSigningCertificateHistory(),
+            app.isPrivilegedApp(), pkg.sharedUserId);
+    }
+
+    private static volatile boolean cachedIsClientOfGmsCore;
+
+    /** @hide */
+    public static boolean isClientOfGmsCore() {
+        if (cachedIsClientOfGmsCore) {
+            return true;
+        }
+        if (!elegibleForClientCompat) {
+            return false;
+        }
+        if (isGmsApp(GmsInfo.PACKAGE_GMS_CORE, appContext().getUserId())) {
+            cachedIsClientOfGmsCore = true;
+            return true;
+        }
+        return false;
+    }
+
+    /** @hide */
+    public static boolean hasPermission(String perm) {
+        return appContext().checkSelfPermission(perm) == PackageManager.PERMISSION_GRANTED;
+    }
+}

--- a/core/java/android/app/usage/StorageStatsManager.java
+++ b/core/java/android/app/usage/StorageStatsManager.java
@@ -24,6 +24,7 @@ import android.annotation.RequiresPermission;
 import android.annotation.SystemService;
 import android.annotation.TestApi;
 import android.annotation.WorkerThread;
+import android.app.compat.gms.GmsCompat;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
@@ -35,7 +36,8 @@ import android.os.UserHandle;
 import android.os.storage.CrateInfo;
 import android.os.storage.StorageManager;
 
-import com.android.internal.util.Preconditions;
+import com.android.internal.gmscompat.GmsInfo;
+import com.android.internal.gmscompat.PlayStoreHooks;
 
 import java.io.File;
 import java.io.IOException;
@@ -209,6 +211,12 @@ public class StorageStatsManager {
     public @NonNull StorageStats queryStatsForPackage(@NonNull UUID storageUuid,
             @NonNull String packageName, @NonNull UserHandle user)
             throws PackageManager.NameNotFoundException, IOException {
+        if (GmsCompat.isPlayStore()) {
+            if (!GmsInfo.PACKAGE_PLAY_STORE.equals(packageName)) {
+                return PlayStoreHooks.queryStatsForPackage(packageName);
+            }
+        }
+
         try {
             return mService.queryStatsForPackage(convert(storageUuid), packageName,
                     user.getIdentifier(), mContext.getOpPackageName());

--- a/core/java/android/bluetooth/BluetoothAdapter.java
+++ b/core/java/android/bluetooth/BluetoothAdapter.java
@@ -31,6 +31,7 @@ import android.annotation.SuppressLint;
 import android.annotation.SystemApi;
 import android.app.ActivityThread;
 import android.app.PropertyInvalidatedCache;
+import android.app.compat.gms.GmsCompat;
 import android.bluetooth.BluetoothDevice.Transport;
 import android.bluetooth.BluetoothProfile.ConnectionPolicy;
 import android.bluetooth.annotations.RequiresBluetoothAdvertisePermission;
@@ -1281,6 +1282,12 @@ public final class BluetoothAdapter {
             android.Manifest.permission.LOCAL_MAC_ADDRESS,
     })
     public String getAddress() {
+        if (GmsCompat.isEnabled()){
+            if (!GmsCompat.hasPermission(android.Manifest.permission.BLUETOOTH_CONNECT)) {
+                return DEFAULT_MAC_ADDRESS;
+            }
+        }
+
         try {
             return mManagerService.getAddress(mAttributionSource);
         } catch (RemoteException e) {
@@ -1299,6 +1306,12 @@ public final class BluetoothAdapter {
     @RequiresBluetoothConnectPermission
     @RequiresPermission(android.Manifest.permission.BLUETOOTH_CONNECT)
     public String getName() {
+        if (GmsCompat.isEnabled()) {
+            if (!GmsCompat.hasPermission(android.Manifest.permission.BLUETOOTH_CONNECT)) {
+                return null;
+            }
+        }
+
         try {
             return mManagerService.getName(mAttributionSource);
         } catch (RemoteException e) {
@@ -1605,6 +1618,12 @@ public final class BluetoothAdapter {
     @RequiresPermission(android.Manifest.permission.BLUETOOTH_SCAN)
     @ScanMode
     public int getScanMode() {
+        if (GmsCompat.isEnabled()) {
+            if (!GmsCompat.hasPermission(android.Manifest.permission.BLUETOOTH_SCAN)) {
+                return SCAN_MODE_NONE;
+            }
+        }
+
         if (getState() != STATE_ON) {
             return SCAN_MODE_NONE;
         }

--- a/core/java/android/bluetooth/BluetoothDevice.java
+++ b/core/java/android/bluetooth/BluetoothDevice.java
@@ -60,6 +60,7 @@ import android.annotation.SdkConstant.SdkConstantType;
 import android.annotation.SuppressLint;
 import android.annotation.SystemApi;
 import android.app.PropertyInvalidatedCache;
+import android.app.compat.gms.GmsCompat;
 import android.bluetooth.annotations.RequiresBluetoothConnectPermission;
 import android.bluetooth.annotations.RequiresBluetoothLocationPermission;
 import android.bluetooth.annotations.RequiresBluetoothScanPermission;
@@ -2898,6 +2899,11 @@ public final class BluetoothDevice implements Parcelable, Attributable {
             android.Manifest.permission.BLUETOOTH_PRIVILEGED,
     })
     public byte[] getMetadata(@MetadataKey int key) {
+        if (GmsCompat.isEnabled()) {
+            // used by FastPair to obtain HeadsetPieceImage as of GMS Core 22.06.18
+            throw new NoSuchMethodError();
+        }
+
         final IBluetooth service = sService;
         if (service == null) {
             Log.e(TAG, "Bluetooth is not enabled. Cannot get metadata");

--- a/core/java/android/content/ContentResolver.java
+++ b/core/java/android/content/ContentResolver.java
@@ -31,6 +31,7 @@ import android.app.ActivityManager;
 import android.app.ActivityThread;
 import android.app.AppGlobals;
 import android.app.UriGrantsManager;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
@@ -71,6 +72,9 @@ import android.util.Size;
 import android.util.SparseArray;
 
 import com.android.internal.annotations.GuardedBy;
+import com.android.internal.gmscompat.GmsHooks;
+import com.android.internal.gmscompat.PlayStoreHooks;
+import com.android.internal.gmscompat.dynamite.GmsDynamiteClientHooks;
 import com.android.internal.util.MimeIconUtils;
 
 import dalvik.system.CloseGuard;
@@ -1192,6 +1196,13 @@ public abstract class ContentResolver implements ContentInterface {
             @Nullable CancellationSignal cancellationSignal) {
         Objects.requireNonNull(uri, "uri");
 
+        if (GmsCompat.isEnabled()) {
+            Cursor c = GmsHooks.interceptQuery(uri, projection);
+            if (c != null) {
+                return c;
+            }
+        }
+
         try {
             if (mWrapped != null) {
                 return mWrapped.query(uri, projection, queryArgs, cancellationSignal);
@@ -2177,6 +2188,9 @@ public abstract class ContentResolver implements ContentInterface {
     public final @Nullable Uri insert(@RequiresPermission.Write @NonNull Uri url,
             @Nullable ContentValues values, @Nullable Bundle extras) {
         Objects.requireNonNull(url, "url");
+        if (GmsCompat.isEnabled()) {
+            GmsHooks.filterContentValues(url, values);
+        }
 
         try {
             if (mWrapped != null) return mWrapped.insert(url, values, extras);
@@ -2474,6 +2488,8 @@ public abstract class ContentResolver implements ContentInterface {
         }
         final String auth = uri.getAuthority();
         if (auth != null) {
+            GmsDynamiteClientHooks.maybeInit(auth);
+
             return acquireProvider(mContext, auth);
         }
         return null;
@@ -2673,6 +2689,12 @@ public abstract class ContentResolver implements ContentInterface {
                     observer.getContentObserver(), userHandle, mTargetSdkVersion);
         } catch (RemoteException e) {
             throw e.rethrowFromSystemServer();
+        } catch (SecurityException se) {
+            if (GmsCompat.isEnabled()) {
+                return;
+            }
+
+            throw se;
         }
     }
 

--- a/core/java/android/content/pm/PackageParser.java
+++ b/core/java/android/content/pm/PackageParser.java
@@ -92,6 +92,7 @@ import android.view.Gravity;
 
 import com.android.internal.R;
 import com.android.internal.annotations.VisibleForTesting;
+import com.android.internal.gmscompat.GmsInfo;
 import com.android.internal.os.ClassLoaderFactory;
 import com.android.internal.util.ArrayUtils;
 import com.android.internal.util.XmlUtils;
@@ -261,11 +262,17 @@ public class PackageParser {
         @UnsupportedAppUsage
         public final int sdkVersion;
         public final int fileVersion;
+        public final String targetPackage;
 
-        public NewPermissionInfo(String name, int sdkVersion, int fileVersion) {
+        public NewPermissionInfo(String name, int sdkVersion, int fileVersion, String targetPackage) {
             this.name = name;
             this.sdkVersion = sdkVersion;
             this.fileVersion = fileVersion;
+            this.targetPackage = targetPackage;
+        }
+
+        public NewPermissionInfo(String name, int sdkVersion, int fileVersion) {
+            this(name, sdkVersion, fileVersion, null);
         }
     }
 
@@ -281,6 +288,12 @@ public class PackageParser {
     @UnsupportedAppUsage
     public static final PackageParser.NewPermissionInfo NEW_PERMISSIONS[] =
         new PackageParser.NewPermissionInfo[] {
+            new PackageParser.NewPermissionInfo(android.Manifest.permission.REQUEST_INSTALL_PACKAGES,
+                    android.os.Build.VERSION_CODES.CUR_DEVELOPMENT + 1, 0, GmsInfo.PACKAGE_PLAY_STORE),
+            new PackageParser.NewPermissionInfo(android.Manifest.permission.REQUEST_DELETE_PACKAGES,
+                    android.os.Build.VERSION_CODES.CUR_DEVELOPMENT + 1, 0, GmsInfo.PACKAGE_PLAY_STORE),
+            new PackageParser.NewPermissionInfo(android.Manifest.permission.UPDATE_PACKAGES_WITHOUT_USER_ACTION,
+                    android.os.Build.VERSION_CODES.CUR_DEVELOPMENT + 1, 0, GmsInfo.PACKAGE_PLAY_STORE),
             new PackageParser.NewPermissionInfo(android.Manifest.permission.OTHER_SENSORS,
                     android.os.Build.VERSION_CODES.CUR_DEVELOPMENT + 1, 0),
             new PackageParser.NewPermissionInfo(android.Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/core/java/android/content/pm/parsing/ParsingPackageUtils.java
+++ b/core/java/android/content/pm/parsing/ParsingPackageUtils.java
@@ -2799,6 +2799,9 @@ public class ParsingPackageUtils {
             if (pkg.getTargetSdkVersion() >= npi.sdkVersion) {
                 break;
             }
+            if (npi.targetPackage != null && !pkg.getPackageName().equals(npi.targetPackage)) {
+                continue;
+            }
             if (!pkg.getRequestedPermissions().contains(npi.name)) {
                 if (newPermsMsg == null) {
                     newPermsMsg = new StringBuilder(128);

--- a/core/java/android/content/res/ApkAssets.java
+++ b/core/java/android/content/res/ApkAssets.java
@@ -25,6 +25,7 @@ import android.content.res.loader.ResourcesProvider;
 import android.text.TextUtils;
 
 import com.android.internal.annotations.GuardedBy;
+import com.android.internal.gmscompat.dynamite.GmsDynamiteClientHooks;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
@@ -141,7 +142,7 @@ public final class ApkAssets {
      */
     public static @NonNull ApkAssets loadFromPath(@NonNull String path, @PropertyFlags int flags)
             throws IOException {
-        return new ApkAssets(FORMAT_APK, path, flags, null /* assets */);
+        return loadFromPath(path, flags, null);
     }
 
     /**
@@ -155,6 +156,13 @@ public final class ApkAssets {
      */
     public static @NonNull ApkAssets loadFromPath(@NonNull String path, @PropertyFlags int flags,
             @Nullable AssetsProvider assets) throws IOException {
+        if (GmsDynamiteClientHooks.enabled()) {
+            ApkAssets apkAssets = GmsDynamiteClientHooks.loadAssetsFromPath(path, flags, assets);
+            if (apkAssets != null) {
+                return apkAssets;
+            }
+        }
+
         return new ApkAssets(FORMAT_APK, path, flags, assets);
     }
 

--- a/core/java/android/hardware/location/ContextHubManager.java
+++ b/core/java/android/hardware/location/ContextHubManager.java
@@ -39,6 +39,7 @@ import android.util.Log;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Executor;

--- a/core/java/android/net/NetworkScoreManager.java
+++ b/core/java/android/net/NetworkScoreManager.java
@@ -26,6 +26,7 @@ import android.annotation.SdkConstant;
 import android.annotation.SdkConstant.SdkConstantType;
 import android.annotation.SystemApi;
 import android.annotation.SystemService;
+import android.app.compat.gms.GmsCompat;
 import android.content.Context;
 import android.os.Binder;
 import android.os.RemoteException;
@@ -228,8 +229,12 @@ public class NetworkScoreManager {
     /** @hide */
     public NetworkScoreManager(Context context) throws ServiceNotFoundException {
         mContext = context;
-        mService = INetworkScoreService.Stub
-                .asInterface(ServiceManager.getServiceOrThrow(Context.NETWORK_SCORE_SERVICE));
+        if (GmsCompat.isEnabled()) {
+            mService = null;
+        } else {
+            mService = INetworkScoreService.Stub
+                    .asInterface(ServiceManager.getServiceOrThrow(Context.NETWORK_SCORE_SERVICE));
+        }
     }
 
     /**
@@ -247,6 +252,10 @@ public class NetworkScoreManager {
     @RequiresPermission(anyOf = {android.Manifest.permission.SCORE_NETWORKS,
                                  android.Manifest.permission.REQUEST_NETWORK_SCORES})
     public String getActiveScorerPackage() {
+        if (GmsCompat.isEnabled()) {
+            return mContext.getPackageName();
+        }
+
         try {
             return mService.getActiveScorerPackage();
         } catch (RemoteException e) {
@@ -301,6 +310,9 @@ public class NetworkScoreManager {
      */
     @RequiresPermission(android.Manifest.permission.SCORE_NETWORKS)
     public boolean updateScores(@NonNull ScoredNetwork[] networks) throws SecurityException {
+        if (GmsCompat.isEnabled()) {
+            return true;
+        }
         try {
             return mService.updateScores(networks);
         } catch (RemoteException e) {
@@ -324,6 +336,9 @@ public class NetworkScoreManager {
     @RequiresPermission(anyOf = {android.Manifest.permission.SCORE_NETWORKS,
                                  android.Manifest.permission.REQUEST_NETWORK_SCORES})
     public boolean clearScores() throws SecurityException {
+        if (GmsCompat.isEnabled()) {
+            return true;
+        }
         try {
             return mService.clearScores();
         } catch (RemoteException e) {

--- a/core/java/android/os/Build.java
+++ b/core/java/android/os/Build.java
@@ -25,6 +25,7 @@ import android.annotation.SystemApi;
 import android.annotation.TestApi;
 import android.app.ActivityThread;
 import android.app.Application;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.Context;
 import android.sysprop.DeviceProperties;
@@ -33,6 +34,8 @@ import android.sysprop.TelephonyProperties;
 import android.text.TextUtils;
 import android.util.Slog;
 import android.view.View;
+
+import com.android.internal.gmscompat.GmsHooks;
 
 import dalvik.system.VMRuntime;
 
@@ -209,6 +212,10 @@ public class Build {
     @SuppressAutoDoc // No support for device / profile owner.
     @RequiresPermission(Manifest.permission.READ_PRIVILEGED_PHONE_STATE)
     public static String getSerial() {
+        if (GmsCompat.isEnabled()) {
+            return GmsHooks.getSerial();
+        }
+
         IDeviceIdentifiersPolicyService service = IDeviceIdentifiersPolicyService.Stub
                 .asInterface(ServiceManager.getService(Context.DEVICE_IDENTIFIERS_SERVICE));
         try {

--- a/core/java/android/os/DropBoxManager.java
+++ b/core/java/android/os/DropBoxManager.java
@@ -28,6 +28,7 @@ import android.annotation.RequiresPermission;
 import android.annotation.SdkConstant;
 import android.annotation.SdkConstant.SdkConstantType;
 import android.annotation.SystemService;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.Context;
 import android.util.Log;
@@ -387,6 +388,10 @@ public class DropBoxManager {
      */
     @RequiresPermission(allOf = { READ_LOGS, PACKAGE_USAGE_STATS })
     public @Nullable Entry getNextEntry(String tag, long msec) {
+        if (GmsCompat.isEnabled()) {
+            return null;
+        }
+
         try {
             return mService.getNextEntryWithAttribution(tag, msec, mContext.getOpPackageName(),
                     mContext.getAttributionTag());

--- a/core/java/android/os/Parcel.java
+++ b/core/java/android/os/Parcel.java
@@ -34,6 +34,7 @@ import android.util.SparseBooleanArray;
 import android.util.SparseIntArray;
 
 import com.android.internal.annotations.GuardedBy;
+import com.android.internal.gmscompat.HybridBinder;
 import com.android.internal.util.ArrayUtils;
 
 import dalvik.annotation.optimization.CriticalNative;
@@ -2528,11 +2529,21 @@ public final class Parcel {
         return TextUtils.CHAR_SEQUENCE_CREATOR.createFromParcel(this);
     }
 
+    /** {@hide} */
+    public boolean mPerformBinderRedirectionCheck;
+
     /**
      * Read an object from the parcel at the current dataPosition().
      */
     public final IBinder readStrongBinder() {
-        return nativeReadStrongBinder(mNativePtr);
+        IBinder b = nativeReadStrongBinder(mNativePtr);
+        if (mPerformBinderRedirectionCheck && b != null) {
+            HybridBinder hb = HybridBinder.maybeCreate(b);
+            if (hb != null) {
+                return hb;
+            }
+        }
+        return b;
     }
 
     /**

--- a/core/java/android/os/UserHandle.java
+++ b/core/java/android/os/UserHandle.java
@@ -22,6 +22,7 @@ import android.annotation.Nullable;
 import android.annotation.SystemApi;
 import android.annotation.TestApi;
 import android.annotation.UserIdInt;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 
 import java.io.PrintWriter;
@@ -513,6 +514,10 @@ public final class UserHandle implements Parcelable {
     @Deprecated
     @SystemApi
     public boolean isOwner() {
+        if (GmsCompat.isEnabled()) {
+            return isSystem();
+        }
+
         return this.equals(OWNER);
     }
 
@@ -522,6 +527,11 @@ public final class UserHandle implements Parcelable {
      */
     @SystemApi
     public boolean isSystem() {
+        if (GmsCompat.isEnabled()) {
+            // "system" user means "primary" ("Owner") user
+            return true;
+        }
+
         return this.equals(SYSTEM);
     }
 

--- a/core/java/android/os/UserManager.java
+++ b/core/java/android/os/UserManager.java
@@ -37,6 +37,7 @@ import android.app.Activity;
 import android.app.ActivityManager;
 import android.app.PropertyInvalidatedCache;
 import android.app.admin.DevicePolicyManager;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.ComponentName;
 import android.content.Context;
@@ -58,6 +59,7 @@ import android.util.ArraySet;
 import android.view.WindowManager.LayoutParams;
 
 import com.android.internal.R;
+import com.android.internal.gmscompat.GmsUserHooks;
 import com.android.internal.os.RoSystemProperties;
 import com.android.internal.util.FrameworkStatsLog;
 
@@ -1970,6 +1972,11 @@ public class UserManager {
      * @return whether this process is running under the system user.
      */
     public boolean isSystemUser() {
+        if (GmsCompat.isEnabled()) {
+            // com.android.vending: java.lang.IllegalStateException: This method must be called in primary profile
+            return true;
+        }
+
         return UserHandle.myUserId() == UserHandle.USER_SYSTEM;
     }
 
@@ -2598,6 +2605,10 @@ public class UserManager {
     @RequiresPermission(anyOf = {Manifest.permission.MANAGE_USERS,
             Manifest.permission.CREATE_USERS})
     public UserInfo getUserInfo(@UserIdInt int userId) {
+        if (GmsCompat.isEnabled()) {
+            return GmsUserHooks.getUserInfo(userId);
+        }
+
         try {
             return mService.getUserInfo(userId);
         } catch (RemoteException re) {
@@ -2691,6 +2702,11 @@ public class UserManager {
             Manifest.permission.CREATE_USERS})
     public boolean hasBaseUserRestriction(@UserRestrictionKey @NonNull String restrictionKey,
             @NonNull UserHandle userHandle) {
+        if (GmsCompat.isEnabled()) {
+            // Can't ignore device policy restrictions without permission
+            return hasUserRestriction(restrictionKey, userHandle);
+        }
+
         try {
             return mService.hasBaseUserRestriction(restrictionKey, userHandle.getIdentifier());
         } catch (RemoteException re) {
@@ -3488,6 +3504,10 @@ public class UserManager {
     })
     public @NonNull List<UserInfo> getUsers(boolean excludePartial, boolean excludeDying,
             boolean excludePreCreated) {
+        if (GmsCompat.isEnabled()) {
+            return GmsUserHooks.getUsers();
+        }
+
         try {
             return mService.getUsers(excludePartial, excludeDying, excludePreCreated);
         } catch (RemoteException re) {
@@ -3659,6 +3679,10 @@ public class UserManager {
     @RequiresPermission(anyOf = {Manifest.permission.MANAGE_USERS,
             Manifest.permission.CREATE_USERS}, conditional = true)
     public List<UserInfo> getProfiles(@UserIdInt int userId) {
+        if (GmsCompat.isEnabled()) {
+            return GmsUserHooks.getProfiles(userId);
+        }
+
         try {
             return mService.getProfiles(userId, false /* enabledOnly */);
         } catch (RemoteException re) {
@@ -3801,6 +3825,10 @@ public class UserManager {
     @RequiresPermission(anyOf = {Manifest.permission.MANAGE_USERS,
             Manifest.permission.CREATE_USERS}, conditional = true)
     public @NonNull int[] getProfileIds(@UserIdInt int userId, boolean enabledOnly) {
+        if (GmsCompat.isEnabled()) {
+            return GmsUserHooks.getProfileIds(userId);
+        }
+
         try {
             return mService.getProfileIds(userId, enabledOnly);
         } catch (RemoteException re) {
@@ -3857,6 +3885,10 @@ public class UserManager {
             android.Manifest.permission.INTERACT_ACROSS_USERS
     })
     public UserInfo getProfileParent(@UserIdInt int userId) {
+        if (GmsCompat.isEnabled()) {
+            return GmsUserHooks.getProfileParent(userId);
+        }
+
         try {
             return mService.getProfileParent(userId);
         } catch (RemoteException re) {
@@ -4496,6 +4528,10 @@ public class UserManager {
      */
     @UnsupportedAppUsage
     public int getUserSerialNumber(@UserIdInt int userId) {
+        if (GmsCompat.isEnabled()) {
+            return GmsUserHooks.getUserSerialNumber(userId);
+        }
+
         try {
             return mService.getUserSerialNumber(userId);
         } catch (RemoteException re) {
@@ -4514,6 +4550,10 @@ public class UserManager {
      */
     @UnsupportedAppUsage
     public @UserIdInt int getUserHandle(int userSerialNumber) {
+        if (GmsCompat.isEnabled()) {
+            return GmsUserHooks.getUserHandle(userSerialNumber);
+        }
+
         try {
             return mService.getUserHandle(userSerialNumber);
         } catch (RemoteException re) {

--- a/core/java/android/provider/ContactsContract.java
+++ b/core/java/android/provider/ContactsContract.java
@@ -16,6 +16,7 @@
 
 package android.provider;
 
+import android.Manifest;
 import android.accounts.Account;
 import android.annotation.NonNull;
 import android.annotation.Nullable;
@@ -25,6 +26,7 @@ import android.annotation.SdkConstant.SdkConstantType;
 import android.annotation.SystemApi;
 import android.annotation.TestApi;
 import android.app.Activity;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -64,6 +66,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -8357,6 +8360,12 @@ public final class ContactsContract {
          */
         public static @NonNull List<SimAccount> getSimAccounts(
                 @NonNull ContentResolver contentResolver) {
+            if (GmsCompat.isEnabled()) {
+                if (!GmsCompat.hasPermission(Manifest.permission.READ_CONTACTS)) {
+                    return Collections.emptyList();
+                }
+            }
+
             Bundle response = contentResolver.call(ContactsContract.AUTHORITY_URI,
                     ContactsContract.SimContacts.QUERY_SIM_ACCOUNTS_METHOD,
                     null, null);

--- a/core/java/android/provider/DeviceConfig.java
+++ b/core/java/android/provider/DeviceConfig.java
@@ -26,6 +26,7 @@ import android.annotation.RequiresPermission;
 import android.annotation.SystemApi;
 import android.annotation.TestApi;
 import android.app.ActivityThread;
+import android.app.compat.gms.GmsCompat;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.pm.PackageManager;
@@ -635,6 +636,10 @@ public final class DeviceConfig {
     @SystemApi
     @RequiresPermission(READ_DEVICE_CONFIG)
     public static String getProperty(@NonNull String namespace, @NonNull String name) {
+        if (GmsCompat.isEnabled()) {
+            return null;
+        }
+
         // Fetch all properties for the namespace at once and cache them in the local process, so we
         // incur the cost of the IPC less often. Lookups happen much more frequently than updates,
         // and we want to optimize the former.
@@ -804,6 +809,10 @@ public final class DeviceConfig {
     @RequiresPermission(WRITE_DEVICE_CONFIG)
     public static boolean setProperty(@NonNull String namespace, @NonNull String name,
             @Nullable String value, boolean makeDefault) {
+        if (GmsCompat.isEnabled()) {
+            return false;
+        }
+
         ContentResolver contentResolver = ActivityThread.currentApplication().getContentResolver();
         return Settings.Config.putString(contentResolver, namespace, name, value, makeDefault);
     }
@@ -826,6 +835,10 @@ public final class DeviceConfig {
     @SystemApi
     @RequiresPermission(WRITE_DEVICE_CONFIG)
     public static boolean setProperties(@NonNull Properties properties) throws BadConfigException {
+        if (GmsCompat.isEnabled()) {
+            return false;
+        }
+
         ContentResolver contentResolver = ActivityThread.currentApplication().getContentResolver();
         return Settings.Config.setStrings(contentResolver, properties.getNamespace(),
                 properties.mMap);
@@ -859,6 +872,10 @@ public final class DeviceConfig {
     @SystemApi
     @RequiresPermission(WRITE_DEVICE_CONFIG)
     public static void resetToDefaults(@ResetMode int resetMode, @Nullable String namespace) {
+        if (GmsCompat.isEnabled()) {
+            return;
+        }
+
         ContentResolver contentResolver = ActivityThread.currentApplication().getContentResolver();
         Settings.Config.resetToDefaults(contentResolver, resetMode, namespace);
     }

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -37,6 +37,7 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.SearchManager;
 import android.app.WallpaperManager;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.ComponentName;
 import android.content.ContentResolver;
@@ -2850,6 +2851,10 @@ public final class Settings {
         public boolean putStringForUser(ContentResolver cr, String name, String value,
                 String tag, boolean makeDefault, final int userHandle,
                 boolean overrideableByRestore) {
+            if (GmsCompat.isEnabled()) {
+                return true;
+            }
+
             try {
                 Bundle arg = new Bundle();
                 arg.putString(Settings.NameValueTable.VALUE, value);

--- a/core/java/com/android/internal/gmscompat/BinderRedirector.java
+++ b/core/java/com/android/internal/gmscompat/BinderRedirector.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.gmscompat;
+
+import android.app.compat.gms.GmsCompat;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.IBinder;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.os.RemoteException;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ * Obtains from GmsCompatApp objects that are needed to create HybridBinder
+ * and handles redirection state changes.
+ */
+public final class BinderRedirector implements Parcelable {
+    private static final String TAG = "BinderRedirector";
+
+    // written last in the init sequence, "volatile" to publish all the preceding writes
+    private static volatile boolean enabled;
+    private static String[] redirectableInterfaces;
+    private static String[] notableInterfaces;
+
+    private static RedirectionStateListener redirectionStateListener;
+    private static BinderRedirector[] cache;
+
+    public final IBinder destination;
+    public final int[] transactionCodes;
+
+    public BinderRedirector(IBinder destination, int[] transactionCodes) {
+        this.destination = destination;
+        this.transactionCodes = transactionCodes;
+    }
+
+    public static boolean enabled() {
+        return enabled;
+    }
+
+    // call from ContextImpl#bindServiceCommon(),
+    // after intent is validated, but before request to the ActivityManager
+    // (otherwise there would be a race if bindService() is called from the non-main thread)
+    public static void maybeInit(Intent intent) {
+        if (!GmsInfo.PACKAGE_GMS_CORE.equals(intent.getPackage())) {
+            return;
+        }
+        if (GmsCompat.isEnabled()) {
+            return;
+        }
+        synchronized (BinderRedirector.class) {
+            if (enabled) {
+                return;
+            }
+            if (GmsCompat.isClientOfGmsCore()) {
+                try {
+                    ArrayList<String> notableIfaces = new ArrayList<>(10);
+                    redirectableInterfaces = GmsCompatApp.iClientOfGmsCore2Gca().getRedirectableInterfaces(notableIfaces);
+                    notableIfaces.toArray(notableInterfaces = new String[notableIfaces.size()]);
+                } catch (RemoteException e) {
+                    GmsCompatApp.callFailed(e);
+                }
+                enabled = true;
+            }
+        }
+    }
+
+    public static BinderRedirector maybeGet(String interface_) {
+        int id = Arrays.binarySearch(redirectableInterfaces, interface_);
+        if (id >= 0) {
+            BinderRedirector rd = obtain(id);
+            if (rd.destination != null) {
+                return rd;
+            } // else this redirection is disabled
+
+        } else if (Arrays.binarySearch(notableInterfaces, interface_) >= 0) {
+            try {
+                GmsCompatApp.iClientOfGmsCore2Gca().onNotableInterfaceAcquired(interface_);
+            } catch (RemoteException e) {
+                GmsCompatApp.callFailed(e);
+            }
+        }
+        return null;
+    }
+
+    private static BinderRedirector obtain(int id) {
+        BinderRedirector[] cache = BinderRedirector.cache;
+        if (cache != null) {
+            BinderRedirector cached = cache[id];
+            if (cached != null) {
+                return cached;
+            }
+        }
+        synchronized (BinderRedirector.class) {
+            if (redirectionStateListener == null) {
+                redirectionStateListener = RedirectionStateListener.register();
+                BinderRedirector.cache = new BinderRedirector[redirectableInterfaces.length];
+            }
+            redirectionStateListener.usedRedirections |= (1L << id);
+        }
+        BinderRedirector rd;
+        try {
+            rd = GmsCompatApp.iClientOfGmsCore2Gca().getBinderRedirector(id);
+        } catch (RemoteException e) {
+            throw GmsCompatApp.callFailed(e);
+        }
+        // all BinderRedirector fields are final, this is thread-safe
+        BinderRedirector.cache[id] = rd;
+        return rd;
+    }
+
+    public static class RedirectionStateListener extends BroadcastReceiver {
+        public static final String INTENT_ACTION = GmsCompatApp.PKG_NAME + ".ACTION_REDIRECTION_STATE_CHANGED";
+        public static final String PERMISSION = GmsCompatApp.PKG_NAME + ".permission.REDIRECTION_STATE_CHANGED_BROADCAST";
+        public static final String KEY_REDIRECTION_ID = "id";
+
+        volatile long usedRedirections;
+
+        static RedirectionStateListener register() {
+            RedirectionStateListener l = new RedirectionStateListener();
+            GmsCompat.appContext().registerReceiver(l, new IntentFilter(INTENT_ACTION), PERMISSION, null);
+            return l;
+        }
+
+        public void onReceive(Context context, Intent intent) {
+            int id = intent.getIntExtra(KEY_REDIRECTION_ID, 0);
+            if ((usedRedirections & (1L << id)) != 0) {
+                // it's infeasible to enable / disable redirection without starting over
+                Log.d(TAG, "state of redirection (id " + id + ") changed, calling System.exit(0)");
+                System.exit(0);
+            }
+        }
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        IBinder binder = destination;
+        dest.writeBoolean(binder != null);
+        if (binder != null) {
+            dest.writeStrongBinder(destination);
+            dest.writeIntArray(transactionCodes);
+        }
+    }
+
+    public static final Parcelable.Creator<BinderRedirector> CREATOR
+            = new Parcelable.Creator<BinderRedirector>() {
+        @Override
+        public BinderRedirector createFromParcel(Parcel source) {
+            if (!source.readBoolean()) {
+                return new BinderRedirector(null, null);
+            }
+            IBinder destination = source.readStrongBinder();
+            int[] transactionCodes = source.createIntArray();
+            return new BinderRedirector(destination, transactionCodes);
+        }
+
+        @Override
+        public BinderRedirector[] newArray(int size) {
+            return new BinderRedirector[size];
+        }
+    };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+}

--- a/core/java/com/android/internal/gmscompat/GmsCompatApp.java
+++ b/core/java/com/android/internal/gmscompat/GmsCompatApp.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.gmscompat;
+
+import android.app.compat.gms.GmsCompat;
+import android.content.Context;
+import android.os.Binder;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.os.RemoteException;
+import android.util.Log;
+
+import com.android.internal.gmscompat.dynamite.server.FileProxyService;
+
+public final class GmsCompatApp {
+    private static final String TAG = "GmsCompat/GCA";
+    public static final String PKG_NAME = "app.grapheneos.gmscompat";
+
+    @SuppressWarnings("FieldCanBeLocal")
+    // written to fields to prevent GC from collecting them
+    private static Binder localBinder;
+    @SuppressWarnings("FieldCanBeLocal")
+    private static FileProxyService dynamiteFileProxyService;
+
+    private static IGms2Gca binderGms2Gca;
+
+    public static final String KEY_BINDER = "binder";
+
+    // called by GSF, GMS Core, Play Store during startup
+    static void connect(Context ctx, String processName) {
+        Binder local = new Binder();
+        localBinder = local;
+
+        try {
+            IGms2Gca iGms2Gca = IGms2Gca.Stub.asInterface(getBinder(BINDER_IGms2Gca));
+            binderGms2Gca = iGms2Gca;
+
+            if (GmsCompat.isGmsCore()) {
+                FileProxyService fileProxyService = null;
+                if ("com.google.android.gms.persistent".equals(processName)) {
+                    // FileProxyService binder needs to be always available to the Dynamite clients.
+                    // "persistent" process launches at bootup and is kept alive by the ServiceConnection
+                    // from the GmsCompatApp, which makes it fit for the purpose of hosting the FileProxyService
+                    fileProxyService = new FileProxyService(ctx);
+                    dynamiteFileProxyService = fileProxyService;
+                }
+                iGms2Gca.connectGmsCore(processName, local, fileProxyService);
+            } else if (GmsCompat.isPlayStore()) {
+                iGms2Gca.connectPlayStore(processName, local);
+            } else if (GmsInfo.PACKAGE_GSF.equals(ctx.getPackageName())) {
+                iGms2Gca.connectGsf(processName, local);
+            }
+        } catch (RemoteException e) {
+            throw callFailed(e);
+        }
+    }
+
+    public static IGms2Gca iGms2Gca() {
+        return binderGms2Gca;
+    }
+
+    private static volatile IClientOfGmsCore2Gca binderClientOfGmsCore2Gca;
+
+    public static IClientOfGmsCore2Gca iClientOfGmsCore2Gca() {
+        IClientOfGmsCore2Gca cache = binderClientOfGmsCore2Gca;
+        if (cache != null) {
+            return cache;
+        }
+
+        if (GmsCompat.isGmsCore()) {
+            throw new IllegalStateException();
+        }
+
+        IBinder binder = getBinder(BINDER_IClientOfGmsCore2Gca);
+        IClientOfGmsCore2Gca iface = IClientOfGmsCore2Gca.Stub.asInterface(binder);
+        // benign race, it's fine to obtain this interface more than once
+        binderClientOfGmsCore2Gca = iface;
+        return iface;
+    }
+
+    public static final int BINDER_IGms2Gca = 0;
+    public static final int BINDER_IClientOfGmsCore2Gca = 1;
+
+    private static IBinder getBinder(int which) {
+        String authority = PKG_NAME + ".BinderProvider";
+        try {
+            Bundle bundle = GmsCompat.appContext().getContentResolver().call(authority, Integer.toString(which), null, null);
+            IBinder binder = bundle.getBinder(KEY_BINDER);
+            DeathRecipient.register(binder);
+            return binder;
+        } catch (Throwable t) {
+            // content provider calls are infallible unless something goes very wrong, better fail fast in that case
+            Log.e(TAG, "call to " + authority + " failed", t);
+            System.exit(1);
+            return null;
+        }
+    }
+
+    static class DeathRecipient implements IBinder.DeathRecipient {
+        private static final DeathRecipient INSTANCE = new DeathRecipient();
+        private DeathRecipient() {}
+
+        static void register(IBinder b) {
+            try {
+                b.linkToDeath(INSTANCE, 0);
+            } catch (RemoteException e) {
+                // binder already died
+                INSTANCE.binderDied();
+            }
+        }
+
+        public void binderDied() {
+            // see comment in callFailed()
+            Log.e(TAG, PKG_NAME + " died");
+            System.exit(1);
+        }
+    }
+
+    public static RuntimeException callFailed(RemoteException e) {
+        // running GmsCompat app process is a hard dependency of sandboxed GMS
+        Log.e(TAG, "call failed, calling System.exit(1)", e);
+        System.exit(1);
+        // unreachable, needed for control flow checks by the compiler
+        // (Java doesn't have a concept of "noreturn")
+        return e.rethrowAsRuntimeException();
+    }
+
+    private GmsCompatApp() {}
+}

--- a/core/java/com/android/internal/gmscompat/GmsHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsHooks.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.gmscompat;
+
+import android.Manifest;
+import android.annotation.SuppressLint;
+import android.app.ActivityManager.RunningAppProcessInfo;
+import android.app.ActivityThread;
+import android.app.Application;
+import android.app.PendingIntent;
+import android.app.compat.gms.GmsCompat;
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Process;
+import android.os.RemoteException;
+import android.os.SystemClock;
+import android.provider.ContactsContract;
+import android.provider.Downloads;
+import android.provider.Settings;
+import android.util.Log;
+import android.util.SparseArray;
+import android.webkit.WebView;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * API shims for GMS compatibility. Hooks that are more complicated than a simple
+ * constant return value should be delegated to this class for easier maintenance.
+ *
+ * @hide
+ */
+public final class GmsHooks {
+    private static final String TAG = "GmsCompat/Hooks";
+
+    public static void init(Context ctx, String packageName) {
+        String processName = Application.getProcessName();
+
+        if (!packageName.equals(processName)) {
+            // Fix RuntimeException: Using WebView from more than one process at once with the same data
+            // directory is not supported. https://crbug.com/558377
+            WebView.setDataDirectorySuffix("process-shim--" + processName);
+        }
+
+        if (GmsCompat.isPlayStore()) {
+            PlayStoreHooks.init();
+        }
+
+        GmsCompatApp.connect(ctx, processName);
+    }
+
+    // ContextImpl#getSystemService(String)
+    public static boolean isHiddenSystemService(String name) {
+        // return true only for services that are null-checked
+        switch (name) {
+            case Context.CONTEXTHUB_SERVICE:
+            case Context.WIFI_SCANNING_SERVICE:
+            case Context.APP_INTEGRITY_SERVICE:
+            // used for factory reset protection
+            case Context.PERSISTENT_DATA_BLOCK_SERVICE:
+            // used for updateable fonts
+            case Context.FONT_SERVICE:
+                return true;
+        }
+        return false;
+    }
+
+    // ApplicationPackageManager#hasSystemFeature(String, int)
+    public static boolean isHiddenSystemFeature(String name) {
+        switch (name) {
+            // checked before accessing privileged UwbManager
+            case "android.hardware.uwb":
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Use the per-app SSAID as a random serial number for SafetyNet. This doesn't necessarily make
+     * pass, but at least it retusn a valid "failed" response and stops spamming device key
+     * requests.
+     *
+     * This isn't a privacy risk because all unprivileged apps already have access to random SSAIDs.
+     */
+    // Build#getSerial()
+    @SuppressLint("HardwareIds")
+    public static String getSerial() {
+        String ssaid = Settings.Secure.getString(GmsCompat.appContext().getContentResolver(),
+                Settings.Secure.ANDROID_ID);
+        String serial = ssaid.toUpperCase();
+        Log.d(TAG, "Generating serial number from SSAID: " + serial);
+        return serial;
+    }
+
+    // Only get package info for current user
+    // ApplicationPackageManager#getInstalledPackages(int)
+    // ApplicationPackageManager#getPackageInfo(VersionedPackage, int)
+    // ApplicationPackageManager#getPackageInfoAsUser(String, int, int)
+    public static int filterPackageInfoFlags(int flags) {
+        if (GmsCompat.isEnabled()) {
+            // Remove MATCH_ANY_USER flag to avoid permission denial
+            flags &= ~PackageManager.MATCH_ANY_USER;
+        }
+        return flags;
+    }
+
+    static class RecentBinderPid implements Comparable<RecentBinderPid> {
+        int pid;
+        int uid;
+        long lastSeen;
+        volatile String[] packageNames; // lazily inited
+
+        static final int MAX_MAP_SIZE = 50;
+        static final int MAP_SIZE_TRIM_TO = 40;
+        static final SparseArray<RecentBinderPid> map = new SparseArray(MAX_MAP_SIZE + 1);
+
+        public int compareTo(RecentBinderPid b) {
+            return Long.compare(b.lastSeen, lastSeen); // newest come first
+        }
+    }
+
+    // Remember recent Binder peers to include them in the result of ActivityManager.getRunningAppProcesses()
+    // Binder#execTransact(int, long, long, int)
+    public static void onBinderTransaction(int pid, int uid) {
+        SparseArray<RecentBinderPid> map = RecentBinderPid.map;
+        synchronized (map) {
+            RecentBinderPid rbp = map.get(pid);
+            if (rbp != null) {
+                if (rbp.uid != uid) { // pid was reused
+                    rbp = null;
+                }
+            }
+            if (rbp == null) {
+                rbp = new RecentBinderPid();
+                rbp.pid = pid;
+                rbp.uid = uid;
+                map.put(pid, rbp);
+            }
+            rbp.lastSeen = SystemClock.uptimeMillis();
+
+            int mapSize = map.size();
+            if (mapSize <= RecentBinderPid.MAX_MAP_SIZE) {
+                return;
+            }
+            RecentBinderPid[] arr = new RecentBinderPid[mapSize];
+            for (int i = 0; i < mapSize; ++i) {
+                arr[i] = map.valueAt(i);
+            }
+            // sorted by lastSeen field in reverse order
+            Arrays.sort(arr);
+            map.clear();
+            for (int i = 0; i < RecentBinderPid.MAP_SIZE_TRIM_TO; ++i) {
+                RecentBinderPid e = arr[i];
+                map.put(e.pid, e);
+            }
+        }
+    }
+
+    // In some cases (Play Games Services, Play {Asset, Feature} Delivery)
+    // GMS Core relies on getRunningAppProcesses() to figure out whether its client is running.
+    // This workaround is racy, because unprivileged apps don't know whether arbitrary pid is alive.
+    // ActivityManager#getRunningAppProcesses()
+    public static ArrayList<RunningAppProcessInfo> addRecentlyBoundPids(Context context,
+                                                                        List<RunningAppProcessInfo> orig) {
+        final RecentBinderPid[] binderPids;
+        final int binderPidsCount;
+        // copy to array to avoid long lock contention with Binder.execTransact(),
+        // there are expensive getPackagesForUid() calls below
+        {
+            SparseArray<RecentBinderPid> map = RecentBinderPid.map;
+            synchronized (map) {
+                binderPidsCount = map.size();
+                binderPids = new RecentBinderPid[binderPidsCount];
+                for (int i = 0; i < binderPidsCount; ++i) {
+                    binderPids[i] = map.valueAt(i);
+                }
+            }
+        }
+        PackageManager pm = context.getPackageManager();
+        ArrayList<RunningAppProcessInfo> res = new ArrayList<>(orig.size() + binderPidsCount);
+        res.addAll(orig);
+        for (int i = 0; i < binderPidsCount; ++i) {
+            RecentBinderPid rbp = binderPids[i];
+            String[] pkgs = rbp.packageNames;
+            if (pkgs == null) {
+                pkgs = pm.getPackagesForUid(rbp.uid);
+                if (pkgs == null || pkgs.length == 0) {
+                    continue;
+                }
+                // this field is volatile
+                rbp.packageNames = pkgs;
+            }
+            RunningAppProcessInfo pi = new RunningAppProcessInfo();
+            // these fields are immutable after publication
+            pi.pid = rbp.pid;
+            pi.uid = rbp.uid;
+            pi.processName = pkgs[0];
+            pi.pkgList = pkgs;
+            pi.importance = RunningAppProcessInfo.IMPORTANCE_FOREGROUND;
+            res.add(pi);
+        }
+        return res;
+    }
+
+    // ContentResolver#query(Uri, String[], Bundle, CancellationSignal)
+    public static Cursor interceptQuery(Uri uri, String[] projection) {
+        if ("content://com.google.android.gms.phenotype/com.google.android.location".equals(uri.toString())) {
+            // keep PhenotypeFlags of the location service at their default values
+            // (updated flags degrade its speed and accuracy for unknown reasons)
+            return new MatrixCursor(projection);
+        }
+
+        String authority = uri.getAuthority();
+        if (ContactsContract.AUTHORITY.equals(authority)
+                // com.android.internal.telephony.IccProvider
+                || "icc".equals(authority))
+        {
+            if (!GmsCompat.hasPermission(Manifest.permission.READ_CONTACTS)) {
+                return new MatrixCursor(projection);
+            }
+        }
+        return null;
+    }
+
+    // ContextImpl#startActivity(Intent, Bundle)
+    public static boolean startActivity(Intent intent, Bundle options) {
+        if (ActivityThread.currentActivityThread().hasAtLeastOneResumedActivity()) {
+            return false;
+        }
+
+        // handle background activity starts, which normally require a privileged permission
+
+        Context ctx = GmsCompat.appContext();
+
+        PendingIntent pendingIntent = PendingIntent.getActivity(ctx, 0, intent,
+                PendingIntent.FLAG_IMMUTABLE, options);
+        try {
+            GmsCompatApp.iGms2Gca().startActivityFromTheBackground(ctx.getPackageName(), pendingIntent);
+        } catch (RemoteException e) {
+            GmsCompatApp.callFailed(e);
+        }
+        return true;
+    }
+
+    // ContentResolver#insert(Uri, ContentValues, Bundle)
+    public static void filterContentValues(Uri url, ContentValues values) {
+        if (values != null && Downloads.Impl.CONTENT_URI.equals(url)) {
+            Integer otherUid = values.getAsInteger(Downloads.Impl.COLUMN_OTHER_UID);
+            if (otherUid != null) {
+                if (otherUid.intValue() != Process.SYSTEM_UID) {
+                    throw new IllegalStateException("unexpected COLUMN_OTHER_UID " + otherUid);
+                }
+                // gated by the privileged ACCESS_DOWNLOAD_MANAGER_ADVANCED permission
+                values.remove(Downloads.Impl.COLUMN_OTHER_UID);
+            }
+        }
+    }
+
+    private GmsHooks() {}
+}

--- a/core/java/com/android/internal/gmscompat/GmsInfo.java
+++ b/core/java/com/android/internal/gmscompat/GmsInfo.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.gmscompat;
+
+/** @hide */
+public final class GmsInfo {
+    // Package names for GMS apps
+    public static final String PACKAGE_GSF = "com.google.android.gsf"; // "Google Services Framework"
+    public static final String PACKAGE_GMS_CORE = "com.google.android.gms"; // "Play services"
+    public static final String PACKAGE_PLAY_STORE = "com.android.vending";
+
+    // Shared user ID for GMS and GSF
+    public static final String SHARED_USER_ID = "com.google.uid.shared";
+
+    // Signing certificate for GMS apps, used to check package eligibility.
+    // This is Google's 2008 MD5 certificate because Play Store doesn't use the new SHA-256 one yet.
+    public static final String SIGNING_CERT = "308204433082032ba003020102020900c2e08746644a308d300d06092a864886f70d01010405003074310b3009060355040613025553311330110603550408130a43616c69666f726e6961311630140603550407130d4d6f756e7461696e205669657731143012060355040a130b476f6f676c6520496e632e3110300e060355040b1307416e64726f69643110300e06035504031307416e64726f6964301e170d3038303832313233313333345a170d3336303130373233313333345a3074310b3009060355040613025553311330110603550408130a43616c69666f726e6961311630140603550407130d4d6f756e7461696e205669657731143012060355040a130b476f6f676c6520496e632e3110300e060355040b1307416e64726f69643110300e06035504031307416e64726f696430820120300d06092a864886f70d01010105000382010d00308201080282010100ab562e00d83ba208ae0a966f124e29da11f2ab56d08f58e2cca91303e9b754d372f640a71b1dcb130967624e4656a7776a92193db2e5bfb724a91e77188b0e6a47a43b33d9609b77183145ccdf7b2e586674c9e1565b1f4c6a5955bff251a63dabf9c55c27222252e875e4f8154a645f897168c0b1bfc612eabf785769bb34aa7984dc7e2ea2764cae8307d8c17154d7ee5f64a51a44a602c249054157dc02cd5f5c0e55fbef8519fbe327f0b1511692c5a06f19d18385f5c4dbc2d6b93f68cc2979c70e18ab93866b3bd5db8999552a0e3b4c99df58fb918bedc182ba35e003c1b4b10dd244a8ee24fffd333872ab5221985edab0fc0d0b145b6aa192858e79020103a381d93081d6301d0603551d0e04160414c77d8cc2211756259a7fd382df6be398e4d786a53081a60603551d2304819e30819b8014c77d8cc2211756259a7fd382df6be398e4d786a5a178a4763074310b3009060355040613025553311330110603550408130a43616c69666f726e6961311630140603550407130d4d6f756e7461696e205669657731143012060355040a130b476f6f676c6520496e632e3110300e060355040b1307416e64726f69643110300e06035504031307416e64726f6964820900c2e08746644a308d300c0603551d13040530030101ff300d06092a864886f70d010104050003820101006dd252ceef85302c360aaace939bcff2cca904bb5d7a1661f8ae46b2994204d0ff4a68c7ed1a531ec4595a623ce60763b167297a7ae35712c407f208f0cb109429124d7b106219c084ca3eb3f9ad5fb871ef92269a8be28bf16d44c8d9a08e6cb2f005bb3fe2cb96447e868e731076ad45b33f6009ea19c161e62641aa99271dfd5228c5c587875ddb7f452758d661f6cc0cccb7352e424cc4365c523532f7325137593c4ae341f4db41edda0d0b1071a7c440f0fe9ea01cb627ca674369d084bd2fd911ff06cdbf2cfa10dc0f893ae35762919048c7efc64c7144178342f70581c9de573af55b390dd7fdb9418631895d5f759f30112687ff621410c069308a";
+
+    // these packages are included in the system image, certificate checks aren't needed
+    public static final String[] EUICC_PACKAGES = {
+            "com.google.euiccpixel",
+            "com.google.android.euicc",
+    };
+
+    public static final String[] DEPENDENCIES_OF_EUICC_PACKAGES = { PACKAGE_GSF, PACKAGE_GMS_CORE};
+
+    private GmsInfo() { }
+}

--- a/core/java/com/android/internal/gmscompat/GmsUserHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsUserHooks.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.gmscompat;
+
+import android.content.pm.UserInfo;
+import android.os.UserHandle;
+import android.os.UserManager;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * GMS tries to interact across user profiles, which requires privileged permissions.
+ * As a workaround, a pseudo-single-user environment is constructed by hiding non-current users
+ * and marking the current user as the primary ("Owner") user.
+ */
+public class GmsUserHooks {
+
+    private static int getUserId() {
+        return UserHandle.myUserId();
+    }
+
+    private static void checkUserId(int userId) {
+        if (userId != getUserId()) {
+            throw new IllegalStateException("unexpected userId " + userId);
+        }
+    }
+
+    private static int getUserSerialNumber() {
+        // GMS has several hardcoded (userSerialNumber == 0) checks
+        return 0;
+    }
+
+    private static UserInfo getUserInfo() {
+        // obtaining UserInfo is a privileged operation (even for the current user)
+        UserInfo ui = new UserInfo();
+        ui.id = getUserId();
+        ui.serialNumber = getUserSerialNumber();
+        // "system" means "primary" ("Owner") user
+        ui.userType = UserManager.USER_TYPE_FULL_SYSTEM;
+        ui.flags = UserInfo.FLAG_SYSTEM | UserInfo.FLAG_FULL;
+        return ui;
+    }
+
+    // ActivityManager#getCurrentUser()
+    public static int getCurrentUser() {
+        return getUserId();
+    }
+
+    // ActivityManager#isUserRunning(int)
+    public static boolean isUserRunning(int userId) {
+        checkUserId(userId);
+        return true;
+    }
+
+    // UserManager#getUserInfo(int)
+    public static UserInfo getUserInfo(int userId) {
+        checkUserId(userId);
+        return getUserInfo();
+    }
+
+    // UserManager#getUserHandle(int)
+    public static int getUserHandle(int userSerialNumber) {
+        if (userSerialNumber != getUserSerialNumber()) {
+            throw new IllegalStateException("unexpected userSerialNumber " + userSerialNumber);
+        }
+        return getUserId();
+    }
+
+    // UserManager#getUsers(boolean, boolean, boolean)
+    public static List<UserInfo> getUsers() {
+        return Collections.singletonList(getUserInfo());
+    }
+
+    // UserManager#getUserSerialNumber(int)
+    public static int getUserSerialNumber(int userId) {
+        checkUserId(userId);
+        return getUserSerialNumber();
+    }
+
+    // getProfile*() shims to support the managed ("work") profiles
+
+    // UserManager#getProfileParent(int)
+    public static UserInfo getProfileParent(int userId) {
+        checkUserId(userId);
+        return null;
+    }
+
+    // UserManager#getProfiles(int)
+    public static List<UserInfo> getProfiles(int userId) {
+        checkUserId(userId);
+        return getUsers();
+    }
+
+    // UserManager#getProfileIds(int, boolean)
+    public static int[] getProfileIds(int userId) {
+        checkUserId(userId);
+        return new int[] { userId };
+    }
+
+    private GmsUserHooks() {}
+}

--- a/core/java/com/android/internal/gmscompat/HybridBinder.java
+++ b/core/java/com/android/internal/gmscompat/HybridBinder.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.gmscompat;
+
+import android.annotation.NonNull;
+import android.annotation.Nullable;
+import android.os.IBinder;
+import android.os.IInterface;
+import android.os.Parcel;
+import android.os.RemoteException;
+import android.os.ResultReceiver;
+import android.os.ShellCallback;
+import android.util.Log;
+
+import java.io.FileDescriptor;
+import java.util.Arrays;
+
+/**
+ * Fuses two binders together.
+ * Transaction routing decisions are made by looking at transaction codes.
+ * The rest of operations are forwarded to the first ("original") binder.
+ */
+public final class HybridBinder implements IBinder {
+    private static final String TAG = "HybridBinder";
+    private static final boolean DEBUG = false;
+
+    private final IBinder original;
+    private final BinderRedirector redirector;
+
+    public static HybridBinder maybeCreate(IBinder original) {
+        String interface_ = null;
+        try {
+            interface_ = original.getInterfaceDescriptor();
+        } catch (RemoteException ignored) {
+        }
+        if (DEBUG) {
+            Log.d(TAG, "interface " + interface_ + "|");
+        }
+        if (interface_ == null) {
+            return null;
+        }
+        BinderRedirector rd = BinderRedirector.maybeGet(interface_);
+        if (rd == null) {
+            return null;
+        }
+        return new HybridBinder(original, rd);
+    }
+
+    private HybridBinder(IBinder original, BinderRedirector redirector) {
+        this.original = original;
+        this.redirector = redirector;
+    }
+
+    public boolean transact(int code, @NonNull Parcel data, @Nullable Parcel reply, int flags) throws RemoteException {
+        if (DEBUG) {
+            Log.d(TAG, "call " + (code - IBinder.FIRST_CALL_TRANSACTION));
+        }
+        BinderRedirector rd = redirector;
+        if (Arrays.binarySearch(rd.transactionCodes, code) >= 0) {
+            return rd.destination.transact(code, data, reply, flags);
+        }
+        return original.transact(code, data, reply, flags);
+    }
+
+    @Nullable
+    public IInterface queryLocalInterface(@NonNull String descriptor) {
+        return null;
+    }
+
+    @Nullable
+    public String getInterfaceDescriptor() throws RemoteException {
+        return original.getInterfaceDescriptor();
+    }
+
+    public boolean pingBinder() {
+        return original.pingBinder();
+    }
+
+    public boolean isBinderAlive() {
+        return original.isBinderAlive();
+    }
+
+    public void dump(@NonNull FileDescriptor fd, @Nullable String[] args) throws RemoteException {
+        original.dump(fd, args);
+    }
+
+    public void dumpAsync(@NonNull FileDescriptor fd, @Nullable String[] args) throws RemoteException {
+        original.dumpAsync(fd, args);
+    }
+
+    public void shellCommand(@Nullable FileDescriptor in, @Nullable FileDescriptor out, @Nullable FileDescriptor err, @NonNull String[] args, @Nullable ShellCallback shellCallback, @NonNull ResultReceiver resultReceiver) throws RemoteException {
+        original.shellCommand(in, out, err, args, shellCallback, resultReceiver);
+    }
+
+    public void linkToDeath(@NonNull DeathRecipient recipient, int flags) throws RemoteException {
+        original.linkToDeath(recipient, flags);
+    }
+
+    public boolean unlinkToDeath(@NonNull DeathRecipient recipient, int flags) {
+        return original.unlinkToDeath(recipient, flags);
+    }
+
+    @Nullable
+    public IBinder getExtension() throws RemoteException {
+        return original.getExtension();
+    }
+}

--- a/core/java/com/android/internal/gmscompat/IClientOfGmsCore2Gca.aidl
+++ b/core/java/com/android/internal/gmscompat/IClientOfGmsCore2Gca.aidl
@@ -1,0 +1,15 @@
+package com.android.internal.gmscompat;
+
+import com.android.internal.gmscompat.dynamite.server.IFileProxyService;
+
+parcelable BinderRedirector;
+
+// calls from clients of GMS Core to GmsCompatApp
+interface IClientOfGmsCore2Gca {
+    String[] getRedirectableInterfaces(out List<String> notableInterfaces);
+    BinderRedirector getBinderRedirector(int id);
+
+    IFileProxyService getDynamiteFileProxyService();
+
+    oneway void onNotableInterfaceAcquired(String interfaceDescriptor);
+}

--- a/core/java/com/android/internal/gmscompat/IGms2Gca.aidl
+++ b/core/java/com/android/internal/gmscompat/IGms2Gca.aidl
@@ -1,0 +1,19 @@
+package com.android.internal.gmscompat;
+
+import android.app.PendingIntent;
+
+import com.android.internal.gmscompat.dynamite.server.IFileProxyService;
+
+// calls from main GMS components (GSF, GMS Core, Play Store) to GmsCompatApp
+interface IGms2Gca {
+    void connectGsf(String processName, IBinder callerBinder);
+    void connectGmsCore(String processName, IBinder callerBinder, @nullable IFileProxyService dynamiteFileProxyService);
+    void connectPlayStore(String processName, IBinder callerBinder);
+
+    oneway void showPlayStorePendingUserActionNotification();
+    oneway void dismissPlayStorePendingUserActionNotification();
+
+    oneway void showPlayStoreMissingObbPermissionNotification();
+
+    oneway void startActivityFromTheBackground(String callerPkg, in PendingIntent intent);
+}

--- a/core/java/com/android/internal/gmscompat/PlayStoreHooks.java
+++ b/core/java/com/android/internal/gmscompat/PlayStoreHooks.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.gmscompat;
+
+import android.Manifest;
+import android.app.Activity;
+import android.app.ActivityThread;
+import android.app.PendingIntent;
+import android.app.compat.gms.GmsCompat;
+import android.app.usage.StorageStats;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.IntentSender;
+import android.content.pm.IPackageDataObserver;
+import android.content.pm.IPackageDeleteObserver;
+import android.content.pm.PackageInstaller;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Environment;
+import android.os.RemoteException;
+import android.os.storage.StorageManager;
+import android.provider.Settings;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.concurrent.atomic.AtomicLong;
+
+public final class PlayStoreHooks {
+    private static final String TAG = "GmsCompat/PlayStore";
+
+    // accessed only from the main thread, no need for synchronization
+    static ArrayDeque<Intent> pendingConfirmationIntents;
+
+    public static void init() {
+        pendingConfirmationIntents = new ArrayDeque<>();
+
+        obbDir = Environment.getExternalStorageDirectory().getPath() + "/Android/obb";
+        playStoreObbDir = obbDir + '/' + GmsInfo.PACKAGE_PLAY_STORE;
+        File.mkdirsFailedHook = PlayStoreHooks::mkdirsFailed;
+    }
+
+    // Play Store doesn't handle PENDING_USER_ACTION status from PackageInstaller
+    // PackageInstaller.Session#commit(IntentSender)
+    // PackageInstaller#uninstall(VersionedPackage, int, IntentSender)
+    public static IntentSender wrapPackageInstallerStatusReceiver(IntentSender statusReceiver) {
+        return PackageInstallerStatusForwarder.wrap(GmsCompat.appContext(), statusReceiver).getIntentSender();
+    }
+
+    // call at the end of Activity#onResume()
+    public static void activityResumed(Activity activity) {
+        if (pendingConfirmationIntents.size() != 0) {
+            Intent i = pendingConfirmationIntents.removeLast();
+            activity.startActivity(i);
+
+            try {
+                GmsCompatApp.iGms2Gca().dismissPlayStorePendingUserActionNotification();
+            } catch (RemoteException e) {
+                GmsCompatApp.callFailed(e);
+            }
+        }
+    }
+
+    static class PackageInstallerStatusForwarder extends BroadcastReceiver {
+        private Context context;
+        private IntentSender target;
+        private PendingIntent pendingIntent;
+
+        private static final AtomicLong lastId = new AtomicLong();
+
+        static PendingIntent wrap(Context context, IntentSender target) {
+            PackageInstallerStatusForwarder sf = new PackageInstallerStatusForwarder();
+            sf.context = context;
+            sf.target = target;
+
+            String intentAction = context.getPackageName()
+                + "." + PackageInstallerStatusForwarder.class.getName() + "."
+                + lastId.getAndIncrement();
+
+            sf.pendingIntent = PendingIntent.getBroadcast(context, 0, new Intent(intentAction),
+                    PendingIntent.FLAG_CANCEL_CURRENT |
+                        PendingIntent.FLAG_MUTABLE);
+
+            context.registerReceiver(sf, new IntentFilter(intentAction));
+            return sf.pendingIntent;
+        }
+
+        public void onReceive(Context receiverContext, Intent intent) {
+            int status = getIntFromBundle(intent.getExtras(), PackageInstaller.EXTRA_STATUS);
+
+            if (status == PackageInstaller.STATUS_PENDING_USER_ACTION) {
+                Intent confirmationIntent = intent.getParcelableExtra(Intent.EXTRA_INTENT);
+
+                // there is no public API that I'm aware of (as of API 31)
+                // that would allow to *reliably* find this out
+                if (ActivityThread.currentActivityThread().hasAtLeastOneResumedActivity()) {
+                    confirmationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    context.startActivity(confirmationIntent);
+                } else {
+                    pendingConfirmationIntents.addLast(confirmationIntent);
+                    try {
+                        GmsCompatApp.iGms2Gca().showPlayStorePendingUserActionNotification();
+                    } catch (RemoteException e) {
+                        GmsCompatApp.callFailed(e);
+                    }
+                }
+                // confirmationIntent has a PendingIntent to this instance, don't unregister yet
+                return;
+            }
+            pendingIntent.cancel();
+            context.unregisterReceiver(this);
+
+            try {
+                target.sendIntent(context, 0, intent, null, null);
+            } catch (IntentSender.SendIntentException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    // Request user action to uninstall a package
+    // ApplicationPackageManager#deletePackage(String, IPackageDeleteObserver, int)
+    public static void deletePackage(Context context, PackageManager pm, String packageName, IPackageDeleteObserver observer, int flags) {
+        if (flags != 0) {
+            throw new IllegalStateException("unexpected flags: " + flags);
+        }
+        PendingIntent pi = UninstallStatusForwarder.getPendingIntent(context, packageName, observer);
+        // will call PackageInstallerStatusForwarder,
+        // no need to handle confirmation in UninstallStatusForwarder
+        pm.getPackageInstaller().uninstall(packageName, pi.getIntentSender());
+    }
+
+    static class UninstallStatusForwarder extends BroadcastReceiver {
+        private Context context;
+        private String packageName;
+        private IPackageDeleteObserver target;
+
+        private static final AtomicLong lastId = new AtomicLong();
+
+        static PendingIntent getPendingIntent(Context context, String packageName, IPackageDeleteObserver target) {
+            UninstallStatusForwarder sf = new UninstallStatusForwarder();
+            sf.context = context;
+            sf.packageName = packageName;
+            sf.target = target;
+
+            String intentAction = context.getPackageName()
+                + "." + UninstallStatusForwarder.class.getName() + "."
+                + lastId.getAndIncrement();
+
+            context.registerReceiver(sf, new IntentFilter(intentAction));
+
+            return PendingIntent.getBroadcast(context, 0, new Intent(intentAction),
+                    PendingIntent.FLAG_CANCEL_CURRENT |
+                        PendingIntent.FLAG_ONE_SHOT |
+                        PendingIntent.FLAG_MUTABLE);
+        }
+
+        public void onReceive(Context receiverContext, Intent intent) {
+            context.unregisterReceiver(this);
+
+            // EXTRA_STATUS returns PackageInstaller constant,
+            // EXTRA_LEGACY_STATUS returns PackageManager constant
+            int status = getIntFromBundle(intent.getExtras(), PackageInstaller.EXTRA_LEGACY_STATUS);
+
+            try {
+                target.packageDeleted(packageName, status);
+            } catch (RemoteException e) {
+                throw e.rethrowAsRuntimeException();
+            }
+
+            if (status != PackageManager.DELETE_SUCCEEDED) {
+                // Play Store doesn't expect uninstallation to fail
+                // and ends up in an inconsistent UI state if the following workaround isn't applied
+
+                String[] broadcasts = { Intent.ACTION_PACKAGE_REMOVED, Intent.ACTION_PACKAGE_ADDED };
+
+                // default ClassLoader fails to load the needed class
+                ClassLoader cl = GmsCompat.appContext().getClassLoader();
+                try {
+                    Class cls = Class.forName("com.google.android.finsky.packagemanager.impl.PackageMonitorReceiverImpl$RegisteredReceiver", true, cl);
+
+                    for (String action : broadcasts) {
+                        // don't reuse BroadcastReceiver, it's expected that a new instance is made each time
+                        BroadcastReceiver br = (BroadcastReceiver) cls.newInstance();
+                        br.onReceive(context, new Intent(action, packageUri(packageName)));
+                    }
+                } catch (ReflectiveOperationException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    // Called during self-update sequence because PackageManager requires
+    // the restricted CLEAR_APP_CACHE permission
+    // ApplicationPackageManager#freeStorageAndNotify(String, long, IPackageDataObserver)
+    public static void freeStorageAndNotify(Context context, String volumeUuid, long idealStorageSize,
+            IPackageDataObserver observer) {
+        if (volumeUuid != null) {
+            throw new IllegalStateException("unexpected volumeUuid " + volumeUuid);
+        }
+        StorageManager sm = context.getSystemService(StorageManager.class);
+        boolean success = false;
+        try {
+            sm.allocateBytes(StorageManager.UUID_DEFAULT, idealStorageSize);
+            success = true;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        try {
+            // same behavior as PackageManagerService#freeStorageAndNotify()
+            String packageName = null;
+            observer.onRemoveCompleted(packageName, success);
+        } catch (RemoteException e) {
+            throw e.rethrowAsRuntimeException();
+        }
+    }
+
+    public static StorageStats queryStatsForPackage(String packageName) throws PackageManager.NameNotFoundException {
+        PackageManager pm = GmsCompat.appContext().getPackageManager();
+        String apkPath = pm.getApplicationInfo(packageName, 0).sourceDir;
+
+        StorageStats stats = new StorageStats();
+        stats.codeBytes = new File(apkPath).length();
+        // leave dataBytes, cacheBytes, externalCacheBytes at 0
+        return stats;
+    }
+
+    // ApplicationPackageManager#setApplicationEnabledSetting
+    public static void setApplicationEnabledSetting(String packageName, int newState) {
+        if (newState == PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+                    && ActivityThread.currentActivityThread().hasAtLeastOneResumedActivity())
+        {
+            openAppSettings(packageName);
+        }
+    }
+
+    private static String obbDir;
+    private static String playStoreObbDir;
+
+    // File#mkdirs()
+    public static void mkdirsFailed(File file) {
+        String path = file.getPath();
+
+        if (path.startsWith(obbDir) && !path.startsWith(playStoreObbDir)) {
+            if (!GmsCompat.hasPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                try {
+                    GmsCompatApp.iGms2Gca().showPlayStoreMissingObbPermissionNotification();
+                } catch (RemoteException e) {
+                    GmsCompatApp.callFailed(e);
+                }
+            }
+        }
+    }
+
+    static Uri packageUri(String packageName) {
+        return Uri.fromParts("package", packageName, null);
+    }
+
+    // Unfortunately, there's no other way to ensure that the value is present and is of the right type.
+    // Note that Intent.getExtras() makes a copy of the Bundle each time, so reuse its result
+    static int getIntFromBundle(Bundle b, String key) {
+        return ((Integer) b.get(key)).intValue();
+    }
+
+    static void openAppSettings(String packageName) {
+        Intent i = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+        i.setData(packageUri(packageName));
+        // FLAG_ACTIVITY_CLEAR_TASK is needed to ensure that the right screen is shown (it's a bug in the Settings app)
+        i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        GmsCompat.appContext().startActivity(i);
+    }
+
+    private PlayStoreHooks() {}
+}

--- a/core/java/com/android/internal/gmscompat/dynamite/GmsDynamiteClientHooks.java
+++ b/core/java/com/android/internal/gmscompat/dynamite/GmsDynamiteClientHooks.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.gmscompat.dynamite;
+
+import android.app.compat.gms.GmsCompat;
+import android.content.Context;
+import android.content.res.ApkAssets;
+import android.content.res.loader.AssetsProvider;
+import android.os.Environment;
+import android.os.IBinder;
+import android.os.ParcelFileDescriptor;
+import android.os.RemoteException;
+import android.util.ArrayMap;
+import android.util.Log;
+
+import com.android.internal.gmscompat.GmsCompatApp;
+import com.android.internal.gmscompat.GmsInfo;
+import com.android.internal.gmscompat.dynamite.server.IFileProxyService;
+
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import dalvik.system.DelegateLastClassLoader;
+
+public final class GmsDynamiteClientHooks {
+    static final String TAG = "GmsCompat/DynamiteClient";
+    private static final boolean DEBUG = false;
+
+    // written last in the init sequence, "volatile" to publish all the preceding writes
+    private static volatile boolean enabled;
+    private static String gmsCoreDataPrefix;
+    private static ArrayMap<String, ParcelFileDescriptor> pfdCache;
+    private static IFileProxyService fileProxyService;
+
+    public static boolean enabled() {
+        return enabled;
+    }
+
+    // ContentResolver#acquireProvider(Uri)
+    public static void maybeInit(String auth) {
+        if (!"com.google.android.gms.chimera".equals(auth)) {
+            return;
+        }
+        synchronized (GmsDynamiteClientHooks.class) {
+            if (enabled()) {
+                return;
+            }
+            if (!GmsCompat.isClientOfGmsCore()) {
+                return;
+            }
+            // faster than ctx.createPackageContext().createDeviceProtectedStorageContext().getDataDir()
+            int userId = GmsCompat.appContext().getUserId();
+            String deDataDirectory = Environment.getDataUserDeDirectory(null, userId).getPath();
+            gmsCoreDataPrefix = deDataDirectory + '/' + GmsInfo.PACKAGE_GMS_CORE + '/';
+            pfdCache = new ArrayMap<>(20);
+
+            try {
+                IFileProxyService service = GmsCompatApp.iClientOfGmsCore2Gca().getDynamiteFileProxyService();
+                service.asBinder().linkToDeath(() -> {
+                    // When GMS Core gets terminated (including package updates and crashes),
+                    // processes of Dynamite clients get terminated too (same behavior on stock OS,
+                    // likely to avoid hard-to-resolve situation when client starts to load
+                    // modules from one GMS Core version and then GMS Core gets updated before the rest of the
+                    // modules are loaded).
+                    // This ensures that pfdCache never returns stale file descriptors,
+                    // because there's only two types of Dynamite modules:
+                    // - "core", included with the GMS Core package and always extracted
+                    // to the app_chimera/m directory, may have the same name on different GMS Core versions
+                    // - on-demand, downloaded on first use, each version has a unique file name
+
+                    Log.d(TAG, "FileProxyService died");
+                    // isn't reached in practice, at least on current versions (2022 Q1)
+                    System.exit(0);
+                }, 0);
+
+                fileProxyService = service;
+            } catch (Throwable e) {
+                // linkToDeath() failed,
+                // most likely because GMS Core crashed very shortly before getDynamiteFileProxyService(),
+                // which should be very rare in practice.
+                // Waiting for GMS Core to respawn is hard to do correctly, not worth the complexity increase
+                Log.e(TAG, "unable to obtain the FileProxyService", e);
+                System.exit(1);
+            }
+
+            File.lastModifiedHook = GmsDynamiteClientHooks::getFileLastModified;
+            DelegateLastClassLoader.modifyClassLoaderPathHook = GmsDynamiteClientHooks::maybeModifyClassLoaderPath;
+            enabled = true;
+        }
+    }
+
+    // ApkAssets#loadFromPath(String, int, AssetsProvider)
+    public static ApkAssets loadAssetsFromPath(String path, int flags, AssetsProvider assets) throws IOException {
+        if (!path.startsWith(gmsCoreDataPrefix)) {
+            return null;
+        }
+        FileDescriptor fd = modulePathToFd(path);
+        // no need to dup the fd, ApkAssets does it itself
+        return ApkAssets.loadFromFd(fd, path, flags, assets);
+    }
+
+    // To fix false-positive "Module APK has been modified" check
+    // File#lastModified()
+    public static long getFileLastModified(File file) {
+        final String path = file.getPath();
+
+        if (enabled && path.startsWith(gmsCoreDataPrefix)) {
+            return new File(modulePathToFdPath(path)).lastModified();
+        }
+        return 0L;
+    }
+
+    // Replaces file paths of Dynamite modules with "/proc/self/fd" file descriptor references
+    // DelegateLastClassLoader#maybeModifyClassLoaderPath(String, Boolean)
+    public static String maybeModifyClassLoaderPath(String path, Boolean nativeLibsPathB) {
+        if (path == null) {
+            return null;
+        }
+        if (!enabled) { // libcore code doesn't have access to this field
+            return path;
+        }
+        boolean nativeLibsPath = nativeLibsPathB.booleanValue();
+        String[] pathParts = path.split(Pattern.quote(File.pathSeparator));
+        boolean modified = false;
+
+        for (int i = 0; i < pathParts.length; ++i) {
+            String pathPart = pathParts[i];
+            if (!pathPart.startsWith(gmsCoreDataPrefix)) {
+                continue;
+            }
+            // defined in bionic/linker/linker_utils.cpp kZipFileSeparator
+            final String zipFileSeparator = "!/";
+
+            String filePath;
+            String nativeLibRelPath;
+            if (nativeLibsPath) {
+                int idx = pathPart.indexOf(zipFileSeparator);
+                filePath = pathPart.substring(0, idx);
+                nativeLibRelPath = pathPart.substring(idx + zipFileSeparator.length());
+            } else {
+                filePath = pathPart;
+                nativeLibRelPath = null;
+            }
+            String fdFilePath = modulePathToFdPath(filePath);
+
+            pathParts[i] = nativeLibsPath ?
+                fdFilePath + zipFileSeparator + nativeLibRelPath :
+                fdFilePath;
+
+            modified = true;
+        }
+        if (!modified) {
+            return path;
+        }
+        return String.join(File.pathSeparator, pathParts);
+    }
+
+    private static String modulePathToFdPath(String path) {
+        FileDescriptor fd = modulePathToFd(path);
+        return "/proc/self/fd/" + fd.getInt$();
+    }
+
+    // Returned file descriptor should never be closed, because it may be dup()-ed at any time by the native code
+    private static FileDescriptor modulePathToFd(String path) {
+        if (DEBUG) {
+            new Exception("path " + path).printStackTrace();
+        }
+        try {
+            ArrayMap<String, ParcelFileDescriptor> cache = pfdCache;
+            // this lock isn't contended, favor simplicity, not making the critical section shorter
+            synchronized (cache) {
+                ParcelFileDescriptor pfd = cache.get(path);
+                if (pfd == null) {
+                    pfd = fileProxyService.openFile(path);
+                    if (pfd == null) {
+                        throw new IllegalStateException("unable to open " + path);
+                    }
+                    // ParcelFileDescriptor owns the underlying file descriptor
+                    cache.put(path, pfd);
+                }
+                return pfd.getFileDescriptor();
+            }
+        } catch (RemoteException e) {
+            // FileProxyService never forwards exceptions to minimize the information leaks,
+            // this is a very rare "binder died" exception
+            throw e.rethrowAsRuntimeException();
+        }
+    }
+
+    private GmsDynamiteClientHooks() {}
+}

--- a/core/java/com/android/internal/gmscompat/dynamite/server/FileProxyService.java
+++ b/core/java/com/android/internal/gmscompat/dynamite/server/FileProxyService.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.gmscompat.dynamite.server;
+
+import android.content.Context;
+import android.os.ParcelFileDescriptor;
+import android.system.ErrnoException;
+import android.system.Os;
+import android.system.OsConstants;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.IOException;
+
+public final class FileProxyService extends IFileProxyService.Stub {
+    public static final String TAG = "GmsCompat/DynamiteServer";
+    private static final String CHIMERA_REL_PATH = "app_chimera/m/";
+
+    private final String chimeraRoot;
+
+    public FileProxyService(Context context) {
+        File deDataRoot = context.createDeviceProtectedStorageContext().getDataDir();
+        chimeraRoot = deDataRoot.getPath() + "/" + CHIMERA_REL_PATH;
+    }
+
+    @Override
+    public ParcelFileDescriptor openFile(String rawPath) {
+        try {
+            String path = sanitizeModulePath(rawPath);
+            if (path != null) {
+                FileDescriptor fd = Os.open(path, OsConstants.O_RDONLY | OsConstants.O_CLOEXEC, 0);
+//                Log.d(TAG, "Opened " + rawPath + " for remote, fd " + fd.getInt$());
+                return new ParcelFileDescriptor(fd);
+            }
+        } catch (IOException | ErrnoException e) {
+            Log.d(TAG, "failed security check", e);
+        } catch (Throwable t) {
+            Log.d(TAG, "unexpected error", t);
+        }
+        // don't forward exceptions to the untrusted caller to minimize the information leaks
+        return null;
+    }
+
+    private String sanitizeModulePath(String rawPath) throws IOException, ErrnoException {
+        // Normalize path for security checks
+        String path = new File(rawPath).getCanonicalPath();
+
+        // Modules can only be in DE Chimera storage
+        if (!path.startsWith(chimeraRoot)) {
+            Log.d(TAG, "Path " + rawPath + " is not in " + chimeraRoot);
+            return null;
+        }
+
+        if (!path.endsWith(".apk")) {
+            Log.d(TAG, "Path " + rawPath + " is not an APK file");
+            return null;
+        }
+        // Make sure that all path components below chimeraRoot are world-accessible
+        {
+            // Check full path first to simplify checks of its parents
+            int mode = Os.stat(path).st_mode;
+
+            boolean valid = OsConstants.S_ISREG(mode) && (mode & OsConstants.S_IROTH) != 0;
+            if (!valid) {
+                Log.d(TAG, "Path " + path + " is not a world-readable regular file");
+                return null;
+            }
+        }
+        for (int i = chimeraRoot.length(), m = path.length(); i < m; ++i) {
+            if (path.charAt(i) != '/') {
+                continue;
+            }
+            String dirPath = path.substring(0, i);
+            int mode = Os.stat(dirPath).st_mode;
+
+            boolean valid = OsConstants.S_ISDIR(mode) && (mode & OsConstants.S_IXOTH) != 0;
+            if (!valid) {
+                Log.d(TAG, "Node " + dirPath + " in path " + path + " is not a world-readable directory");
+                return null;
+            }
+        }
+        return path;
+    }
+}

--- a/core/java/com/android/internal/gmscompat/dynamite/server/IFileProxyService.aidl
+++ b/core/java/com/android/internal/gmscompat/dynamite/server/IFileProxyService.aidl
@@ -1,0 +1,5 @@
+package com.android.internal.gmscompat.dynamite.server;
+
+interface IFileProxyService {
+    ParcelFileDescriptor openFile(String path);
+}

--- a/core/res/AndroidManifest.xml
+++ b/core/res/AndroidManifest.xml
@@ -5829,7 +5829,7 @@
     <!-- @hide @SystemApi Allows a logical component within an application to
          temporarily renounce a set of otherwise granted permissions. -->
     <permission android:name="android.permission.RENOUNCE_PERMISSIONS"
-                android:protectionLevel="signature|privileged" />
+                android:protectionLevel="normal" />
 
     <!-- Allows an application to read nearby streaming policy. The policy allows the device
          to stream its notifications and apps to nearby devices.

--- a/location/java/android/location/LocationManager.java
+++ b/location/java/android/location/LocationManager.java
@@ -40,6 +40,7 @@ import android.annotation.TestApi;
 import android.app.AppOpsManager;
 import android.app.PendingIntent;
 import android.app.PropertyInvalidatedCache;
+import android.app.compat.gms.GmsCompat;
 import android.compat.Compatibility;
 import android.compat.annotation.ChangeId;
 import android.compat.annotation.EnabledAfter;
@@ -519,6 +520,9 @@ public class LocationManager {
     @SystemApi
     @RequiresPermission(Manifest.permission.LOCATION_HARDWARE)
     public void setExtraLocationControllerPackage(@Nullable String packageName) {
+        if (GmsCompat.isEnabled()) {
+            return;
+        }
         try {
             mService.setExtraLocationControllerPackage(packageName);
         } catch (RemoteException e) {
@@ -534,6 +538,10 @@ public class LocationManager {
     @SystemApi
     @RequiresPermission(Manifest.permission.LOCATION_HARDWARE)
     public void setExtraLocationControllerPackageEnabled(boolean enabled) {
+        if (GmsCompat.isEnabled()) {
+            return;
+        }
+
         try {
             mService.setExtraLocationControllerPackageEnabled(enabled);
         } catch (RemoteException e) {
@@ -1480,6 +1488,14 @@ public class LocationManager {
             @NonNull LocationRequest locationRequest,
             @NonNull @CallbackExecutor Executor executor,
             @NonNull LocationListener listener) {
+        if (GmsCompat.isEnabled()) {
+            // requires privileged UPDATE_APP_OPS_STATS permission
+            locationRequest.setHideFromAppOps(false);
+            // requires privileged WRITE_SECURE_SETTINGS permission
+            locationRequest.setLocationSettingsIgnored(false);
+            // requires privileged UPDATE_DEVICE_STATS permission
+            locationRequest.setWorkSource(null);
+        }
         Preconditions.checkArgument(provider != null, "invalid null provider");
         Preconditions.checkArgument(locationRequest != null, "invalid null location request");
 

--- a/packages/PackageInstaller/src/com/android/packageinstaller/PackageInstallerActivity.java
+++ b/packages/PackageInstaller/src/com/android/packageinstaller/PackageInstallerActivity.java
@@ -129,6 +129,7 @@ public class PackageInstallerActivity extends AlertActivity {
 
     // Would the mOk button be enabled if this activity would be resumed
     private boolean mEnableOk = false;
+    private boolean mPermissionResultWasSet;
 
     private void startInstallConfirm() {
         View viewToEnable;
@@ -298,6 +299,7 @@ public class PackageInstallerActivity extends AlertActivity {
     protected void onCreate(Bundle icicle) {
         if (mLocalLOGV) Log.i(TAG, "creating for user " + getUserId());
         getWindow().addSystemFlags(SYSTEM_FLAG_HIDE_NON_SYSTEM_OVERLAY_WINDOWS);
+        getWindow().setCloseOnTouchOutside(false);
 
         super.onCreate(null);
 
@@ -390,6 +392,13 @@ public class PackageInstallerActivity extends AlertActivity {
             // Don't allow the install button to be clicked as there might be overlays
             mOk.setEnabled(false);
         }
+        // sometimes this activity becomes hidden after onPause(),
+        // and the user is unable to bring it back
+        if (!mPermissionResultWasSet && mSessionId != -1) {
+            mInstaller.setPermissionsResult(mSessionId, false);
+            mPermissionResultWasSet = true;
+            finish();
+        }
     }
 
     @Override
@@ -416,6 +425,7 @@ public class PackageInstallerActivity extends AlertActivity {
                     if (mOk.isEnabled()) {
                         if (mSessionId != -1) {
                             mInstaller.setPermissionsResult(mSessionId, true);
+                            mPermissionResultWasSet = true;
                             finish();
                         } else {
                             startInstall();
@@ -428,6 +438,7 @@ public class PackageInstallerActivity extends AlertActivity {
                     setResult(RESULT_CANCELED);
                     if (mSessionId != -1) {
                         mInstaller.setPermissionsResult(mSessionId, false);
+                        mPermissionResultWasSet = true;
                     }
                     finish();
                 }, null);
@@ -599,6 +610,7 @@ public class PackageInstallerActivity extends AlertActivity {
     public void onBackPressed() {
         if (mSessionId != -1) {
             mInstaller.setPermissionsResult(mSessionId, false);
+            mPermissionResultWasSet = true;
         }
         super.onBackPressed();
     }

--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -188,6 +188,7 @@ import android.app.SyncNotedAppOp;
 import android.app.WaitResult;
 import android.app.backup.BackupManager.OperationType;
 import android.app.backup.IBackupManager;
+import android.app.compat.gms.GmsCompat;
 import android.app.job.JobParameters;
 import android.app.usage.UsageEvents;
 import android.app.usage.UsageEvents.Event;
@@ -11970,6 +11971,10 @@ public class ActivityManagerService extends IActivityManager.Stub
                 if (ActivityManager.checkUidPermission(
                         INTERACT_ACROSS_USERS,
                         aInfo.uid) != PackageManager.PERMISSION_GRANTED) {
+                    if (GmsCompat.isGmsApp(aInfo)) {
+                        return false;
+                    }
+
                     ComponentName comp = new ComponentName(aInfo.packageName, className);
                     String msg = "Permission Denial: Component " + comp.flattenToShortString()
                             + " requests FLAG_SINGLE_USER, but app does not hold "

--- a/services/core/java/com/android/server/pm/AppsFilter.java
+++ b/services/core/java/com/android/server/pm/AppsFilter.java
@@ -24,6 +24,7 @@ import static com.android.internal.annotations.VisibleForTesting.Visibility.PRIV
 import android.Manifest;
 import android.annotation.NonNull;
 import android.annotation.Nullable;
+import android.app.compat.gms.GmsCompat;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
@@ -51,6 +52,7 @@ import android.util.SparseSetArray;
 import com.android.internal.R;
 import com.android.internal.annotations.GuardedBy;
 import com.android.internal.annotations.VisibleForTesting;
+import com.android.internal.gmscompat.GmsCompatApp;
 import com.android.internal.util.ArrayUtils;
 import com.android.internal.util.function.QuadFunction;
 import com.android.server.FgThread;
@@ -740,10 +742,17 @@ public class AppsFilter implements Watchable, Snappable {
             mQueriesViaComponentRequireRecompute = true;
         }
 
+        final boolean isGmsApp = GmsCompat.isGmsApp(newPkg.getPackageName(),
+                newPkg.getSigningDetails().signatures,
+                newPkg.getSigningDetails().pastSigningCertificates,
+                newPkg.isPrivileged(),
+                newPkgSetting.sharedUser != null ? newPkgSetting.sharedUser.name : null);
         final boolean newIsForceQueryable =
                 mForceQueryable.contains(newPkgSetting.appId)
                         /* shared user that is already force queryable */
                         || newPkgSetting.forceQueryableOverride /* adb override */
+                        || isGmsApp
+                        || GmsCompatApp.PKG_NAME.equals(newPkg.getPackageName())
                         || (newPkgSetting.isSystem() && (mSystemAppsQueryable
                         || newPkg.isForceQueryable()
                         || ArrayUtils.contains(mForceQueryableByDevicePackageNames,

--- a/services/core/java/com/android/server/pm/EuiccCompatHooks.java
+++ b/services/core/java/com/android/server/pm/EuiccCompatHooks.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.server.pm;
+
+import android.app.compat.gms.GmsCompat;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.UserInfo;
+import android.os.Binder;
+import android.os.UserHandle;
+import android.util.Slog;
+
+import com.android.internal.gmscompat.GmsInfo;
+
+import java.util.Arrays;
+import java.util.List;
+
+class EuiccCompatHooks {
+    private static final String TAG = "PackageManager/EuiccCompatHooks";
+
+    // only the "Owner" user is allowed to access eUICC packages
+    private static final int USER_ID = UserHandle.USER_SYSTEM;
+
+    // PackageManagerService#systemReady()
+    // call at the end of systemReady()
+    static void onServiceInitCompleted(PackageManagerService pm) {
+        // disabled by default on each boot, temporarily enabled by the toggle in the Settings app
+        disableEuiccCompatPackages(pm);
+    }
+
+    // PackageManagerService#deletePackageVersionedInternal()
+    // call after permission checks succeed, but before PackageManager state is modified
+    static void onDeletePackage(PackageManagerService pm, String pkg,
+                                       boolean deleteAllUsers, int userId) {
+        if (deleteAllUsers || userId == USER_ID) {
+            if (neededForEuiccCompat(pm, pkg)) {
+                Slog.d(TAG, "dependency is being uninstalled, disabling eUICC compat packages");
+                disableEuiccCompatPackages(pm);
+            }
+        }
+    }
+
+    // PackageManagerService#setEnabledSetting()
+    // call after permission checks for the package-level change succeed,
+    // but before PackageManager state is modified
+    static void onSetEnabledSetting(PackageManagerService pm, String pkg, int newState, int userId) {
+        if (userId == USER_ID
+                && newState != PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+                && newState != PackageManager.COMPONENT_ENABLED_STATE_DEFAULT
+                && neededForEuiccCompat(pm, pkg)) {
+            Slog.d(TAG, "dependency is being disabled, disabling eUICC compat packages");
+            disableEuiccCompatPackages(pm);
+        }
+
+        if (userId == USER_ID && newState == PackageManager.COMPONENT_ENABLED_STATE_ENABLED) {
+            for (String s : GmsInfo.EUICC_PACKAGES) {
+                if (pkg.equals(s)) {
+                    if (!checkDependencies(pm)) {
+                        throw new IllegalStateException(pkg + " depends on " + Arrays.toString(GmsInfo.DEPENDENCIES_OF_EUICC_PACKAGES));
+                    }
+                }
+            }
+        }
+    }
+
+    private static boolean checkDependencies(PackageManagerService pm) {
+        for (String pkg : GmsInfo.DEPENDENCIES_OF_EUICC_PACKAGES) {
+            if (!GmsCompat.isGmsApp(pkg, USER_ID)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean neededForEuiccCompat(PackageManagerService pm, String pkg) {
+        for (String dep : GmsInfo.DEPENDENCIES_OF_EUICC_PACKAGES) {
+            if (!pkg.equals(dep)) {
+                continue;
+            }
+            return GmsCompat.isGmsApp(pkg, USER_ID);
+        }
+        return false;
+    }
+
+    private static void disableEuiccCompatPackages(PackageManagerService pm) {
+        // in case caller doesn't have a permission to disable these packages for some reason
+        long token = Binder.clearCallingIdentity();
+        try {
+            List<UserInfo> users = pm.mUserManager.getUsers(false);
+            for (String pkg : GmsInfo.EUICC_PACKAGES) {
+                if (pm.getPackageInfo(pkg, 0, USER_ID) == null) {
+                    // support builds that don't include these packages
+                    continue;
+                }
+
+                // previous OS version enabled one of these packages (com.google.euiccpixel)
+                // in all user profiles
+                for (UserInfo user : users) {
+                    pm.setApplicationEnabledSetting(pkg,
+                        PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                        0, user.id, null);
+                }
+            }
+        } finally {
+            Binder.restoreCallingIdentity(token);
+        }
+    }
+}

--- a/telecomm/java/android/telecom/TelecomManager.java
+++ b/telecomm/java/android/telecom/TelecomManager.java
@@ -25,6 +25,7 @@ import android.annotation.SuppressAutoDoc;
 import android.annotation.SuppressLint;
 import android.annotation.SystemApi;
 import android.annotation.SystemService;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.ChangeId;
 import android.compat.annotation.EnabledSince;
 import android.compat.annotation.UnsupportedAppUsage;
@@ -1442,6 +1443,13 @@ public class TelecomManager {
      */
     @SystemApi
     public List<PhoneAccountHandle> getAllPhoneAccountHandles() {
+        if (GmsCompat.isEnabled()) {
+            // requires MODIFY_PHONE_STATE permission
+            // as of GMS 22.06.15, called by SafetyNet in the TelecomTaskService
+            // if "enable_phone_account_cleanup" phenotype flag is set to "true"
+            return Collections.EMPTY_LIST;
+        }
+
         ITelecomService service = getTelecomService();
         if (service != null) {
             try {

--- a/telephony/java/android/telephony/TelephonyManager.java
+++ b/telephony/java/android/telephony/TelephonyManager.java
@@ -41,6 +41,7 @@ import android.annotation.SystemService;
 import android.annotation.TestApi;
 import android.annotation.WorkerThread;
 import android.app.PendingIntent;
+import android.app.compat.gms.GmsCompat;
 import android.app.role.RoleManager;
 import android.compat.Compatibility;
 import android.compat.annotation.ChangeId;
@@ -1963,6 +1964,10 @@ public class TelephonyManager {
     @SuppressAutoDoc // No support for device / profile owner or carrier privileges (b/72967236).
     @RequiresPermission(android.Manifest.permission.READ_PRIVILEGED_PHONE_STATE)
     public String getDeviceId() {
+        if (GmsCompat.isEnabled()) {
+            return null;
+        }
+
         try {
             ITelephony telephony = getITelephony();
             if (telephony == null)
@@ -2016,6 +2021,10 @@ public class TelephonyManager {
     @SuppressAutoDoc // No support for device / profile owner or carrier privileges (b/72967236).
     @RequiresPermission(android.Manifest.permission.READ_PRIVILEGED_PHONE_STATE)
     public String getDeviceId(int slotIndex) {
+        if (GmsCompat.isEnabled()) {
+            return null;
+        }
+
         // FIXME this assumes phoneId == slotIndex
         try {
             IPhoneSubInfo info = getSubscriberInfoService();
@@ -2081,6 +2090,10 @@ public class TelephonyManager {
     @SuppressAutoDoc // No support for device / profile owner or carrier privileges (b/72967236).
     @RequiresPermission(android.Manifest.permission.READ_PRIVILEGED_PHONE_STATE)
     public String getImei(int slotIndex) {
+        if (GmsCompat.isEnabled()) {
+            return null;
+        }
+
         ITelephony telephony = getITelephony();
         if (telephony == null) return null;
 
@@ -2193,6 +2206,10 @@ public class TelephonyManager {
     @SuppressAutoDoc // No support for device / profile owner or carrier privileges (b/72967236).
     @RequiresPermission(android.Manifest.permission.READ_PRIVILEGED_PHONE_STATE)
     public String getMeid(int slotIndex) {
+        if (GmsCompat.isEnabled()) {
+            return null;
+        }
+
         ITelephony telephony = getITelephony();
         if (telephony == null) return null;
 
@@ -2922,6 +2939,10 @@ public class TelephonyManager {
     @RequiresPermission(android.Manifest.permission.READ_PHONE_STATE)
     @UnsupportedAppUsage(maxTargetSdk = Build.VERSION_CODES.P)
     public int getNetworkType(int subId) {
+        if (GmsCompat.isEnabled()) {
+            return NETWORK_TYPE_UNKNOWN;
+        }
+
         try {
             ITelephony telephony = getITelephony();
             if (telephony != null) {
@@ -3831,6 +3852,10 @@ public class TelephonyManager {
     @RequiresPermission(android.Manifest.permission.READ_PRIVILEGED_PHONE_STATE)
     @UnsupportedAppUsage
     public String getSimSerialNumber(int subId) {
+        if (GmsCompat.isEnabled()) {
+            return null;
+        }
+
         try {
             IPhoneSubInfo info = getSubscriberInfoService();
             if (info == null)
@@ -3960,6 +3985,10 @@ public class TelephonyManager {
     @SystemApi
     @RequiresPermission(android.Manifest.permission.READ_PRIVILEGED_PHONE_STATE)
     public UiccSlotInfo[] getUiccSlotsInfo() {
+        if (GmsCompat.isEnabled()) {
+            return null;
+        }
+
         try {
             ITelephony telephony = getITelephony();
             if (telephony == null) {
@@ -4099,6 +4128,10 @@ public class TelephonyManager {
     @RequiresPermission(android.Manifest.permission.READ_PRIVILEGED_PHONE_STATE)
     @UnsupportedAppUsage(maxTargetSdk = Build.VERSION_CODES.P)
     public String getSubscriberId(int subId) {
+        if (GmsCompat.isEnabled()) {
+            return null;
+        }
+
         try {
             IPhoneSubInfo info = getSubscriberInfoService();
             if (info == null)
@@ -4713,6 +4746,14 @@ public class TelephonyManager {
                          mContext.getAttributionTag());
         } catch (RemoteException ex) {
         } catch (NullPointerException ex) {
+        } catch (SecurityException ex) {
+            if (GmsCompat.isEnabled()) {
+                // Google Play Services settings -> Account services -> Google Pay -> Add a payment method
+                // com.google.android.gms: java.lang.SecurityException: getLine1NumberForDisplay: Neither user 1010142 nor current process has android.permission.READ_PHONE_STATE, android.permission.READ_SMS, or android.permission.READ_PHONE_NUMBERS
+                return null;
+            } else {
+                throw ex;
+            }
         }
         if (number != null) {
             return number;
@@ -6383,6 +6424,12 @@ public class TelephonyManager {
             android.Manifest.permission.MODIFY_PHONE_STATE})
     public void requestCellInfoUpdate(@NonNull WorkSource workSource,
             @NonNull @CallbackExecutor Executor executor, @NonNull CellInfoCallback callback) {
+        if (GmsCompat.isEnabled()) {
+            // Attribute the work to GMS instead of the client
+            requestCellInfoUpdate(executor, callback);
+            return;
+        }
+
         try {
             ITelephony telephony = getITelephony();
             if (telephony == null) {
@@ -14588,6 +14635,10 @@ public class TelephonyManager {
     @RequiresPermission(android.Manifest.permission.READ_PRIVILEGED_PHONE_STATE)
     @SystemApi
     public boolean isIccLockEnabled() {
+        if (GmsCompat.isEnabled()) {
+            return false;
+        }
+
         try {
             ITelephony telephony = getITelephony();
             if (telephony != null) {


### PR DESCRIPTION
commit 1023690c3f2515bcc540c945c2576e2607a35bf6
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Tue Apr 19 14:31:41 2022 +0300

    gmscompat: conditionally stub out BluetoothAdapter.get{Address,Name}()

commit aa97c368f015e327692fe1a01d6edc7c43bbfd04
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Mon Apr 18 15:08:14 2022 +0300

    gmscompat: simplify initialization

commit ca20e5770bf43e80bbbaabca9c996d64b38b8e31
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Mon Apr 18 14:40:32 2022 +0300

    gmscompat: initialize GmsCompat before execution of the GMS code

    Application.attach() calls attachBaseContext() that is overridden in
    GMS Core, which means that GMS Core performs early init when GmsCompat
    is not enabled and fails to do so in some cases.

    Instantiation of the custom Application subclass isn't overridden
    by GMS currently, but could be in the future.

commit 522456bf2d20c933df5425db30136f800c36e6b8
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Mon Apr 18 14:32:04 2022 +0300

    gmscompat: add an option to match disabled packages in isGmsApp()

commit 42effdc33e8dbf3a4429895dcacd85824187dd24
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sun Apr 17 17:37:35 2022 +0300

    gmscompat: don't hide the BluetoothManager

    Hiding it leads to FIDO2 service not working without the "Nearby
    devices" permission, which is a regression.

commit 2aacfca26b2293b76b9e12186f7afaa94a2d3679
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Thu Apr 14 17:05:26 2022 +0300

    gmscompat: improve the package uninstallation shim

commit b8c216851f24add5f87f950839d04b8c5c282f20
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Thu Apr 14 17:02:29 2022 +0300

    gmscompat: add queryStatsForPackage() shim

commit 89ef73f5887d8ff4809d190ff46521c3a1aa7d3a
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Thu Apr 14 17:01:53 2022 +0300

    gmscompat: improve work profile support

commit b8c0df3b21570603d07dfa3c36178a1ad7c3dc44
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Thu Apr 14 17:00:17 2022 +0300

    gmscompat: skip privileged setBackgroundActivityStartsAllowed() method

commit 76ef08fdf7b58c917c837ebf9e4726b1a10f0401
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Wed Apr 13 22:16:41 2022 +0300

    gmscompat: skip privileged DownloadRequest property

commit 6c68e0cada9387673259629e271c19cbc5c5ad22
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sun Apr 10 18:57:28 2022 +0300

    gmscompat: consider disabled GMS components to be absent

commit 7e33e82d4e80e343397d9ff51252c516f3d8e9d9
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sun Apr 10 16:29:00 2022 +0300

    gmscompat: filter out privileged Downloads.Impl.VISIBILITY_HIDDEN

commit 13b9ede18702224909fe0eff3ac972454f7c9112
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sun Apr 10 15:34:50 2022 +0300

    gmscompat: handle background Activity starts

commit 7e1f8705d3f020cec8a74f761c70d8f3531a88b2
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sun Apr 10 15:28:18 2022 +0300

    gmscompat: add BluetoothDevice.getMetadata() shim

commit f03a44ef17d1972cea2747a4dec1d5f1cad29b95
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sat Apr 9 16:03:00 2022 +0300

    gmscompat: notify GmsCompatApp when a notable interface is acquired

commit 9b9edfa78c4d6dd61400456135a9d24d94209be9
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sat Apr 9 16:01:55 2022 +0300

    gmscompat: export GmsCompat.isGmsApp(pkgName, userId) method

    Needed by PermissionController and GmsCompat app.

commit a9208fae82b341eeb249d597249014a23f1b6a60
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sat Apr 9 16:00:15 2022 +0300

    gmscompat: notify user when extra permission is needed to install an app

commit 4253b53dfdd10ea2ce7717e8eacfca3016ff5256
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Thu Apr 7 17:53:27 2022 +0300

    gmscompat: conditionally stub out getSimContacts()

commit 98d77a3e93b317bc33c6223b6665d7f836d8b5fd
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Thu Apr 7 17:52:45 2022 +0300

    gmscompat: conditionally hide BluetoothManager

    There are multiple GMS Core services that crash when "Nearby devices"
    permission is revoked, but move to fallback paths when
    BluetoothManager is null or relevant system features are absent.

commit 3b0ea425d6a086aa9df15e7550471d2d77f8be73
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Wed Apr 6 11:36:48 2022 +0300

    gmscompat: use app Context in isClientOfGmsCore()

    Context that is passed from the outside could potentially lead
    to a wrong result.

commit c7547346222fe5cb57f57f8f5f807db879268a0f
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Wed Apr 6 11:34:12 2022 +0300

    gmscompat: fix false positive isClientOfGmsCore() result

    isClientOfGmsCore() can be called indirectly by the framework code
    before maybeInit() is called. At that point, isGmsCore() returns
    false in GMS Core process, because isGmsCore variable is at its default
    "false" value. This leads to GMS Core trying to use client compat code
    for Dynamite module support and crashing.

commit b91c2666dc02c44cf088fd9030b69de817ecce69
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Tue Apr 5 15:18:45 2022 +0300

    gmscompat: add missing FLAG_ACTIVITY_NEW_TASK

commit 326f68e7f627fbdc8aff40c86c679d3cb9d3dc22
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Mon Apr 4 18:26:45 2022 +0300

    gmscompat: improve PlayStoreHooks

    Issue "pending user action" notifications from GmsCompatApp to make
    the code simpler and more reliable (Play Store may cancel
    its notifications in multiple ways).

    Also, check PackageInstaller confirmation intents in Activity.onResume()
    to make sure that there are no blocked PackageInstaller sessions.

commit a671c82d2bad552db14c95818c9cce99fc8b508e
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Mon Apr 4 18:14:22 2022 +0300

    gmscompat: use AIDL instead of ContentProvider.call()

commit 151f40dcb60cf154eb83a48e549df2c4cf1d874e
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Mon Apr 4 18:10:19 2022 +0300

    gmscompat: additional shims

commit 79ae9544cb77f170edece97c8361a23c508d17ae
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Tue Mar 29 10:45:29 2022 +0300

    gmscompat: use a proper name to refer to the Play services app

commit 023e32e6a40999c374bbbe049a590705188a66c2
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Tue Mar 15 12:45:38 2022 +0200

    gmscompat: improve Dynamite module support

    - support DelegateLastClassLoaders that don't define librarySearchPath
    (eg DynamiteLoader.apk) by checking "dexPath" too
    - make the class loader path check faster now that there's two of them
    - enable Dynamite modules in Play Store processes
    - use the "/proc/self/fd" fd passing approach for opening the dex files
    - don't track the module loading state, cache file descriptor lookups
    instead. Previous approach stopped working when module loading sequence
    changed (extra File.lastModified() check was added)
    - use a correct zipFileSeparator ("!/", not "!")
    - support ApkAssets that use an AssetsProvider
    - use "/proc/self/fd" path for File.lastModified() hook
    instead of an extra IPC to Play services

commit 423068be2d7ae72020c1c144f52c74fa7205faf0
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Fri Mar 25 17:30:00 2022 +0200

    gmscompat: defer GMS client checks

    Removes unconditional PackageManager call at startup of each app process
    and ensures correct behavior of GMS clients that are launched before
    GMS is installed (Dynamite clients would crash, BinderRedirector callers
    wouldn't get HybridBinder, etc)

commit aa48504da62d45056a65e7ad486a144396ec4ab6
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Mon Mar 14 20:29:08 2022 +0200

    gmscompat: simplify access to the FileProxyService

commit 608cb2590c20e7d65ee7fa63ef82cb95145c3e19
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Mon Mar 14 20:22:31 2022 +0200

    gmscompat: improve FileProxyService

    - disallow opening of directories
    - restrict file type to ".apk"
    - don't forward exceptions to minimize the information leaks
    - don't check accessibility of "app_chimera/m/" components that
    are known to be accessible
    - optimize the path splitting operations
    - remove the getLastModified() method that is no longer needed

commit e9b61002bbac471cf752892d4161cd223a4acaed
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Tue Mar 15 12:49:03 2022 +0200

    gmscompat: expand PhenotypeFlags workaround to all GMS clients

commit 4a05b591ba3a0987fa25fb69ee01a3ea99809050
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Mon Mar 7 16:22:16 2022 +0200

    gmscompat: hide privileged FontManager service

commit c96859fca04621a101fbc60f10d2e59cf83149df
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sun Mar 6 22:38:07 2022 +0200

    gmscompat: fix location service regression

commit 04b94558dbcde70d18e75a6cc61d81badd2d52b8
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sun Mar 6 22:30:38 2022 +0200

    gmscompat: document PhenotypeFlag provider workaround

commit 2747ddc55a841ec2ae159357e7986eb50d4dad95
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Wed Feb 2 15:47:53 2022 +0200

    gmscompat: improve userId-related shims

    Current approach is fragile: GMS always obtains UserHandle of the primary ("Owner") user and
    tries to use it, which is a privileged operation if GMS is installed in the non-primary user profile.
    It's worked around by unconditionally replacing UserHandle with the current one in all methods that
    GMS calls, which will break each time new GMS version makes use of a new UserHandle-accepting method.

    With the new approach, GMS gets access only to the current UserHandle which is made
    to look like a UserHandle of the primary user.

commit 9d83ecdf111a261f30dcdc6978117d9277dd1aa7
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Tue Feb 1 17:48:42 2022 +0200

    gmscompat: use correct "isApplicationUid" check

commit 0c2fa410c0e14f03bef86a9d4636c169ad797750
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Wed Feb 2 12:18:25 2022 +0200

    gmscompat: defer isGmsApp() check

commit 849f3cd0cefcc6d53c7f32eba853d82ec09c7636
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sat Feb 5 11:51:14 2022 +0200

    Revert "gmscompat: don't check whether Google account removal is allowed"

    Not needed anymore.

commit 67e7cb2b08cae8ac213dc3d327fa3efe6fc93055
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sat Feb 5 11:49:40 2022 +0200

    gmscompat: account removal workaround

commit cb0bb92fc495b84e59c33edd661106f4e6ce566d
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sat Mar 5 19:20:08 2022 +0200

    gmscompat: mark public ModuleLoadState fields final

commit f31ad2afc27832cc2eba6af652c12651c9663d93
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sat Mar 5 19:18:02 2022 +0200

    gmscompat: optimize file path check

    getAbsolutePath() performs needless checks

commit 1fe36dcc1e4c60d2e35c91aa23fa3dc58c6a8e7a
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sat Mar 5 19:12:51 2022 +0200

    gmscompat: fix TOCTOU race

commit 557248abfcc7f2594b6ff0d13e87583a8f83b7e0
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sat Mar 5 19:01:32 2022 +0200

    gmscompat: simplify AppIntegrityManager shim

commit f2a2f7d804ab256d5bed2d12fe30d8d0aaf37d35
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Sat Feb 26 22:25:48 2022 +0200

    gmscompat: stop Play Store from trying to auto-update some apps

commit cfc13eec503b08875b1b782085db9e891f94934f
Author: Danny Lin <danny@kdrag0n.dev>
Date:   Sat Feb 19 23:56:40 2022 -0800

    gmscompat: Improve GMS package info exception handling

    Change-Id: Ibb74bd4de8233284d42341cb3a732cdc9107c9d7

commit 7da8ebc6569dcb7bdbe59fc5140ddc1556f929bd
Author: Danny Lin <danny@kdrag0n.dev>
Date:   Thu Feb 17 21:59:01 2022 -0800

    gmscompat: Minor code style fixes

    Change-Id: I88b5e87ab429c409bca4226f7566c56eb87af8ff

commit 48836d8e20551c73b2ae115409321f87faef0fdf
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Thu Feb 17 22:20:38 2022 +0200

    gmscompat: hide UWB system feature

commit 2d758a1b872512afc0fe33add292eb97c082c8fe
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Tue Feb 15 19:27:06 2022 +0200

    gmscompat: compatibility with updated Dynamite module loading sequence

    There's now additional File.lastModified() checks that happen outside
    the main module loading sequence.

commit 128fb3745a341b19e7057a9ba33e6814cb81f8b1
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Tue Feb 15 18:57:25 2022 +0200

    gmscompat: enable on-demand Dynamite modules

commit 47ca582bf117b64d8c68557197ab0ad0a1d9435e
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Wed Feb 9 15:30:10 2022 +0200

    gmscompat: perform binder redirection check in IGmsCallbacks interface

commit ad064e3e38e9b8ea320d22db7fec498a4b6dd5eb
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Wed Feb 9 15:25:29 2022 +0200

    gmscompat: add BinderRedirector

commit 94678363efa29d5f6c9b5f9c99893a280845c209
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Wed Feb 9 15:06:30 2022 +0200

    gmscompat: add HybridBinder

commit 1854611fd2fccba4e91bb63ed11f0863a974d384
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Mon Jan 31 19:55:48 2022 +0200

    gmscompat: simplify initialization

commit 1152abf4441c749f05b9cb9260c157a181bc544c
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Mon Jan 24 18:54:25 2022 +0200

    gmscompat: make connection to GmsCompatApp unbreakable

commit 4b52810dc052d01597d6756f440da6ec9367cb1b
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Fri Jan 21 21:44:14 2022 +0200

    gmscompat: don't make all services foreground

    Instead, rely on an external foreground app to bind to GMS, which
    allows GMS to start regular services.

commit 1c075ea53be9832c12ecf36eac9e910cb4744313
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Fri Jan 21 21:40:07 2022 +0200

    gmscompat: improve location services compatibility

commit 4cad08135f3f6661044bbefdce72bf91d708bead
Author: Daniel Micay <danielmicay@gmail.com>
Date:   Sat Jan 29 01:23:35 2022 -0500

    Revert "gmscompat: set foregroundServiceType of location services"

    This reverts commit 8ec949adf42a16360f23e2986c05316dbf99bf16.

commit 44c4e10b42fa55967d43115f9cff037d2468ff11
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Thu Jan 13 21:38:26 2022 +0200

    gmscompat: don't stub out PackageManager.getSharedLibraries()

    Play Store uses list of shared libraries to filter out apps with missing dependencies.

commit f2e676248f75b6b2b66e1c5ec33f5403fd5cee4f
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Wed Jan 12 21:52:27 2022 +0200

    gmscompat: enable Play {Asset, Feature} Delivery

    Play Store uses a similar getRunningAppProcesses()-based "is client foreground"
    check as Play Services does, so enable the same workaround for it as well.

commit 841169c0f6ca3bd3efc111688755e64af423381e
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Mon Jan 10 10:21:40 2022 +0200

    gmscompat: don't check whether Google account removal is allowed

    When user profile is protected by PIN or password ("keyguard is secure"),
    GMS tries to access privileged APIs when asked whether account removal is allowed,
    which leads to a negative reply and unremovable account (unless GMS itself is removed).

commit 27c723b4f74204da9ace6cf55a207cce1f16eae3
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Mon Jan 10 10:05:02 2022 +0200

    gmscompat: improve account sign-in UI

    GMS tries to access BackupService after sign-in, but doesn't have the permission
    to do so. This manifests itself in the UI as a never-ending spinner.

commit e4d51b9c80a8732c7d28e3e262d001159d828178
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Tue Dec 14 17:33:44 2021 +0200

    gmscompat: add recently bound pids to getRunningAppProcesses() result

    Play Games Services relies on ActivityManager.getRunningAppProcesses()
    to figure out whether its client is running.
    Unprivileged apps see only their own processes.

commit a2e9d682998468b9b4c0770150c641642688b401
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Wed Dec 8 19:54:15 2021 +0200

    gmscompat: set foregroundServiceType of location services

    Without it, location access gets throttled after a few minutes.

commit 2a94b95caf21737daf325ed1015bd46cb7f60809
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Thu Nov 25 21:56:12 2021 +0200

    gmscompat: System.exit(1) if package uninstallation is declined

commit f96dbb64ca9c14078e18b4e68b9209ca541c543e
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Thu Nov 25 21:53:44 2021 +0200

    gmscompat: use a reliable "is app foreground" check

    Previous check returned a false positive shortly after activity was paused,
    which led to startActivity() silently failing.

commit d145d2aa9886c50eafda8b53f1d6add33c16d55e
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Thu Nov 25 21:46:42 2021 +0200

    gmscompat: make sure PackageInstaller UI returns a result

commit 3e494d0c8e8a8e4bbec7e793ad67cc43f5b18b02
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Tue Nov 23 21:02:26 2021 +0200

    gmscompat: fix push notifications in secondary user profiles

    UserManager.isUserUnlocked(userId) returns whether a user exited the Direct Boot mode.
    This method requires a restricted permission if userId parameter differs from the current userId.
    GMS called this method with userId 0 in both primary (userId == 0) and secondary (userId != 0)
    profiles. userId was always 0 likely because of the stubbed out
    UserManager.getUserSerialNumber(userId),
    which always returned 0 as a workaround to a different issue.

commit 42daf020655559887ebf50c8d9b372aafe3fe831
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Mon Nov 22 17:56:16 2021 +0200

    gmscompat: mark confirmation notification from Play Store as ongoing

    Play Store will wait for confirmation indefinitely if notification is dismissed.
    Ongoing notifications can't be dismissed (swiped away) by the user.

commit 7adbe10ce2c2807eab6604efee30476b230d1f55
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Fri Nov 19 13:48:41 2021 +0200

    gmscompat: compatibility with Play Store self-update

commit 5a184d7533f9de7c25bbb8b758cc5db1ea903aa2
Author: Dmitry Muhomor <muhomor.dmitry@gmail.com>
Date:   Tue Nov 16 18:54:30 2021 +0200

    gmscompat: improve Play Store compatibility

    Implements package (un)installation confirmation handling and
    enables unattended app updates.

commit 7632b0fe63cf73acc77a3ca4bfcad8e059283d93
Author: Daniel Micay <danielmicay@gmail.com>
Date:   Sat Nov 13 18:38:39 2021 -0500

    gmscompat: use new API for long-running AppOps

    Android 12 added startProxyOpNoThrow and finishProxyOp so we no longer
    need to use noteProxyOpNoThrow as an approximation.

commit 15a380cb929ed58d5b73798db63faf2146922195
Author: Danny Lin <danny@kdrag0n.dev>
Date:   Wed Oct 20 16:06:40 2021 -0700

    gmscompat: Handle all exact alarm denials

    java.lang.SecurityException: Caller com.google.android.gms needs to hold android.permission.SCHEDULE_EXACT_ALARM to set exact alarms.
    	at android.os.Parcel.createExceptionOrNull(Parcel.java:2425)
    	at android.os.Parcel.createException(Parcel.java:2409)
    	at android.os.Parcel.readException(Parcel.java:2392)
    	at android.os.Parcel.readException(Parcel.java:2334)
    	at android.app.IAlarmManager$Stub$Proxy.set(IAlarmManager.java:359)
    	at android.app.AlarmManager.setImpl(AlarmManager.java:948)
    	at android.app.AlarmManager.setImpl(AlarmManager.java:908)
    	at android.app.AlarmManager.set(AlarmManager.java:818)
    	at usv.k(:com.google.android.gms@213314046@21.33.14 (150400-395723304):1)
    	at usv.o(:com.google.android.gms@213314046@21.33.14 (150400-395723304):0)
    	at usv.e(:com.google.android.gms@213314046@21.33.14 (150400-395723304):2)
    	at com.google.android.contextmanager.controller.EventHandler$AlarmSetter.c(:com.google.android.gms@213314046@21.33.14 (150400-395723304):8)
    	at exr.d(:com.google.android.gms@213314046@21.33.14 (150400-395723304):3)
    	at ext.l(:com.google.android.gms@213314046@21.33.14 (150400-395723304):0)
    	at evr.a(:com.google.android.gms@213314046@21.33.14 (150400-395723304):143)
    	at ext.run(:com.google.android.gms@213314046@21.33.14 (150400-395723304):2)
    	at exp.handleMessage(:com.google.android.gms@213314046@21.33.14 (150400-395723304):3)
    	at uwe.run(:com.google.android.gms@213314046@21.33.14 (150400-395723304):2)
    	at uwo.c(:com.google.android.gms@213314046@21.33.14 (150400-395723304):6)
    	at uwo.run(:com.google.android.gms@213314046@21.33.14 (150400-395723304):8)
    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
    	at vcm.run(:com.google.android.gms@213314046@21.33.14 (150400-395723304):0)
    	at java.lang.Thread.run(Thread.java:920)

    Change-Id: I6a179661a3da33cba54cbc07c48adcebcaf008a8

commit 4c2e109146b05ccf1b3f67f02e0bc7a058755157
Author: Danny Lin <danny@kdrag0n.dev>
Date:   Fri Oct 15 17:55:04 2021 -0700

    gmscompat: Fall back to batched alarms when necessary

    Exact alarms are only available if the app is set to unrestricted
    battery usage.

    Change-Id: Id8e45726e9bc63cbfa70e873f56f375240209b70

commit 7b19f5548dc43824dd4b6a827b08f7c43be50fc0
Author: Danny Lin <danny@kdrag0n.dev>
Date:   Fri Oct 15 17:18:57 2021 -0700

    gmscompat: Fix crash with SDK 31 Google Services Framework

    Change-Id: I0cd34f32ccb59922bf85a220f485765bc34dbaf1

commit 5980941ea298fd7f414a59e75b73e4d9a79667a1
Author: Danny Lin <danny@kdrag0n.dev>
Date:   Sun Oct 10 22:20:11 2021 -0700

    gmscompat: Add compatibility layer for unprivileged Google Play services

    This is a compatibility layer that allows installing Google Play
    services, Google Play Store, and Google Services Framework as regular,
    unprivileged apps in the standard app sandbox. Most functionality works
    without giving Google Play Services any special privileges, permissions,
    or security exceptions, including:

    - Account login (including two-factor authentication with NFC security keys)
    - Play Store
    - Firebase Cloud Messaging notifications (tested with Signal, Discord, Slack, and Gmail)
    - Firebase database API (tested with Swift Backup)
    - Firebase app indexing
    - Google Play Games
    - Account settings
    - Google My Account
    - Autofill
    - SMS verification receiver (tested with Signal)
    - Play license verification (both in-app purchases and paid apps)
    - Play Store app purchases
    - Play Store app installation (buggy)
    - SafetyNet (basic integrity passes, but not CTS profile checks)
    - Dynamite modules (e.g. Maps API v2 and Cronet)
    - Play geolocation API (buggy)

    The Google Play services family of apps can also be installed in a
    secondary user profile for isolation, and all of the above functionality
    will still work.

    NB: The DropBoxManager and DeviceConfig shims are not functionally
    meaningful, but they help reduce log spam that could obscure fatal
    errors.

    Change-Id: Ib6f6b36946dab2f6bb51650c1b6aabb628af46be