### PR TITLE
ElectronBeam: Fix SystemUI FatalException with Netflix and certian us…

### DIFF
--- a/services/core/java/com/android/server/display/ElectronBeam.java
+++ b/services/core/java/com/android/server/display/ElectronBeam.java
@@ -598,8 +598,8 @@ final class ElectronBeam implements ScreenStateAnimator {
                     EGL14.EGL_NONE
             };
             if (isProtected) {
-                eglContextAttribList[2] = EGL_PROTECTED_CONTENT_EXT;
-                eglContextAttribList[3] = EGL14.EGL_TRUE;
+                eglContextAttribList[1] = EGL_PROTECTED_CONTENT_EXT;
+                eglContextAttribList[2] = EGL14.EGL_TRUE;
             }
             mEglContext = EGL14.eglCreateContext(mEglDisplay, mEglConfig, EGL14.EGL_NO_CONTEXT,
                     eglContextAttribList, 0);


### PR DESCRIPTION
…ecases

* Kind of an oddly specific use case here but to reproduce:
  - Enable CRT Screen Off Animation
  - Start playing a video from Netflix.
  - now leave the netflix app playing in the background and
    go to lockscreen, you should see the crash then.

Signed-off-by: Matt Filetto <matt.filetto@gmail.com>