### PR TITLE
QSBrightnessSlider: Fix adjusting when auto-brightness icon is hidden

### DIFF
--- a/packages/SystemUI/res/layout/quick_settings_brightness_dialog.xml
+++ b/packages/SystemUI/res/layout/quick_settings_brightness_dialog.xml
@@ -31,7 +31,7 @@
         <com.android.systemui.settings.brightness.ToggleSeekBar
             android:id="@+id/slider"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="48dp"
             android:layout_gravity="center_vertical"
             android:minHeight="48dp"
             android:thumb="@null"


### PR DESCRIPTION
* Bug: When adjusting the brightness via the Quick settings panel
  while also having the "Hide Auto-brightness Button" Feature enabled
  (so there is no auto-brightness toggle in qs panel) and attempt to
  adjust brightness via the slider the whole panel becomes black
  and sometimes the slider dissapears other times it moves downward.

  Fix: During the dotOS QSPanel merge there was a change to some
  layout.xml and there was a mismerge it seems. Simply reverted the
  value to what it was prior

Signed-off-by: Matt Filetto <matt.filetto@gmail.com>