### PR TITLE
Switched to 4 icons on qqs for landscape

### DIFF
--- a/packages/SystemUI/res/values/spark_config.xml
+++ b/packages/SystemUI/res/values/spark_config.xml
@@ -69,10 +69,10 @@
 
     <!-- The number of columns in the QuickQSPanel -->
     <integer name="quick_qs_panel_num_columns">4</integer>
-    <integer name="quick_qs_panel_num_columns_landscape">6</integer>
+    <integer name="quick_qs_panel_num_columns_landscape">4</integer>
     <integer name="quick_qs_panel_num_columns_media">4</integer>
 
     <!--The number of columns in the QSPanel -->
     <integer name="qs_panel_num_columns">4</integer>
-    <integer name="qs_panel_num_columns_landscape">6</integer>
+    <integer name="qs_panel_num_columns_landscape">4</integer>
 </resources>


### PR DESCRIPTION
when expanding qs in landscape it goes to 4 icons insted of 6 wich looks worst , make in 4 in qqs landscape for better transition

Signed-off-by: drkphnx <dark.phnx12@gmail.com>