### PR TITLE
Revert "core: Avoid using accelerated graphics by default"

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -203,7 +203,7 @@
          is true (in that case this is assumed true as well).  It can allow you to tune down
          your device's memory use without going to the point of causing applications to turn
          off features. -->
-    <bool name="config_avoidGfxAccel">true</bool>
+    <bool name="config_avoidGfxAccel">false</bool>
 
     <!-- Device configuration setting the minfree tunable in the lowmemorykiller in the kernel.
          A high value will cause the lowmemorykiller to fire earlier, keeping more memory


### PR DESCRIPTION
* Breaks Wallpaper and styles section (causes overscroll)

This reverts commit e767c1f41a45bf0c1744171b64e8f6060ee0e34c.