### PR TITLE
SystemUI: Fix current formatting on lockscreen

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
@@ -996,7 +996,9 @@ public class KeyguardIndicationController {
             Settings.System.LOCKSCREEN_BATTERY_INFO, 1, UserHandle.USER_CURRENT) == 1;
          if (showbatteryInfo) {
             if (mChargingCurrent > 0) {
-                batteryInfo = batteryInfo + (mChargingCurrent / 1000) + "mA";
+                batteryInfo = batteryInfo + (mChargingCurrent < 5 ?
+                        (mChargingCurrent * 1000) : (mChargingCurrent < 4000 ?
+                        mChargingCurrent : (mChargingCurrent / 1000))) + "mA";
             }
             if (mChargingWattage > 0) {
                 batteryInfo = (batteryInfo == "" ? "" : batteryInfo + " · ") +


### PR DESCRIPTION
* for devices that report directly in Ampere.

Shamelessly extracted from:
    base: Lockscreen Charging info (3/3) by: xyyx <xyyx@mail.ru>

original commit-message:

 base: Lockscreen Charging info (3/3)

 based on: [2/2] frameworks: show charging current & voltage on lockscreen by
 yank555-lu [2/2]Base: show more battery info on lockscreen when charging by
 yank555-lu LockscreenCharging: Use double for mChargingVoltage and show as
 4.XV by xyyx Lockscreen charging: Formatting improvements by nathanchance

AICPfy:
- default set to false
- Current formatting improvement for devices reporting directly in Amps

Change-Id: I67bc4fb44129b68f14be8106c1bdad53e2744a28