### PR TITLE
Restrict contentprovider from starting new process

### DIFF
--- a/services/core/java/com/android/server/am/ContentProviderHelper.java
+++ b/services/core/java/com/android/server/am/ContentProviderHelper.java
@@ -497,11 +497,12 @@ public class ContentProviderHelper {
                                     PROVIDER_ACQUISITION_EVENT_REPORTED__PROC_START_TYPE__PROCESS_START_TYPE_WARM);
                         } else {
                             checkTime(startTime, "getContentProviderImpl: before start process");
+			    final boolean caller_is_bg = ActivityManager.isProcStateBackground(r.mState.getCurProcState());
 			    final int allowed = mService.getAppStartModeLOSP(cpr.appInfo.uid, cpr.appInfo.packageName,
 									     cpr.appInfo.targetSdkVersion,
 									     Binder.getCallingPid(),
-									     false, false, false);
-			    if (allowed != ActivityManager.APP_START_MODE_NORMAL) {
+									     false, false, caller_is_bg);
+			    if (caller_is_bg && allowed != ActivityManager.APP_START_MODE_NORMAL) {
 				return null;
 			    }
                             proc = mService.startProcessLocked(

--- a/services/core/java/com/android/server/am/ContentProviderHelper.java
+++ b/services/core/java/com/android/server/am/ContentProviderHelper.java
@@ -503,6 +503,9 @@ public class ContentProviderHelper {
 									     Binder.getCallingPid(),
 									     false, false, caller_is_bg);
 			    if (caller_is_bg && allowed != ActivityManager.APP_START_MODE_NORMAL) {
+				Slog.d(TAG, "Stopped " + r.info.packageName +
+				       " from starting content provider in "
+				       + cpr.appInfo.packageName);
 				return null;
 			    }
                             proc = mService.startProcessLocked(

--- a/services/core/java/com/android/server/am/ContentProviderHelper.java
+++ b/services/core/java/com/android/server/am/ContentProviderHelper.java
@@ -497,6 +497,13 @@ public class ContentProviderHelper {
                                     PROVIDER_ACQUISITION_EVENT_REPORTED__PROC_START_TYPE__PROCESS_START_TYPE_WARM);
                         } else {
                             checkTime(startTime, "getContentProviderImpl: before start process");
+			    final int allowed = mService.getAppStartModeLOSP(cpr.appInfo.uid, cpr.appInfo.packageName,
+									     cpr.appInfo.targetSdkVersion,
+									     Binder.getCallingPid(),
+									     false, false, false);
+			    if (allowed != ActivityManager.APP_START_MODE_NORMAL) {
+				return null;
+			    }
                             proc = mService.startProcessLocked(
                                     cpi.processName, cpr.appInfo, false, 0,
                                     new HostingRecord(HostingRecord.HOSTING_TYPE_CONTENT_PROVIDER,


### PR DESCRIPTION
Currently background service will not get started if there is no existing process for the service, and the app is in background restriction state, but not for content providers. This leave a loophole for bad apps to wake up each other. This patch fix this problem.